### PR TITLE
Enable half precision training

### DIFF
--- a/auto_deeplab.py
+++ b/auto_deeplab.py
@@ -3,12 +3,13 @@ import torch.nn as nn
 import numpy as np
 import cell_level_search
 from genotypes import PRIMITIVES
+from genotypes import Genotype
 import torch.nn.functional as F
 from operations import *
-from decoding_formulas import Decoder
+from decode import Decoder
 
 class AutoDeeplab (nn.Module) :
-    def __init__(self, num_classes, num_layers, criterion = None, filter_multiplier = 8, block_multiplier = 5, step = 5, cell=cell_level_search.Cell):
+    def __init__(self, num_classes, num_layers, criterion, filter_multiplier = 8, block_multiplier = 5, step = 5, cell=cell_level_search.Cell):
         super(AutoDeeplab, self).__init__()
 
         self.cells = nn.ModuleList()
@@ -42,111 +43,116 @@ class AutoDeeplab (nn.Module) :
         # def __init__(self, steps, multiplier, C_prev_prev, C_initial, C, rate) : rate = 0 , 1, 2  reduce rate
 
             if i == 0 :
-                cell1 = cell (self._step, self._block_multiplier, -1,
-                              None, intitial_fm, None,
-                              self._filter_multiplier)
-                cell2 = cell (self._step, self._block_multiplier, -1,
-                              intitial_fm, None, None,
-                              self._filter_multiplier * 2)
+                cell1 = cell (self._step, self._block_multiplier, -1, intitial_fm, self._filter_multiplier, 1)
+                cell2 = cell (self._step, self._block_multiplier, -1, intitial_fm, self._filter_multiplier * 2, 2)
                 self.cells += [cell1]
                 self.cells += [cell2]
             elif i == 1 :
-                cell1 = cell (self._step, self._block_multiplier, intitial_fm,
-                              None, self._filter_multiplier, self._filter_multiplier * 2,
-                              self._filter_multiplier)
+                cell1_1 = cell (self._step, self._block_multiplier, intitial_fm, self._filter_multiplier, self._filter_multiplier, 1)
+                cell1_2 = cell (self._step, self._block_multiplier, intitial_fm, self._filter_multiplier * 2, self._filter_multiplier, 0)
 
-                cell2 = cell (self._step, self._block_multiplier, -1,
-                              self._filter_multiplier, self._filter_multiplier * 2, None,
-                              self._filter_multiplier * 2)
+                cell2_1 = cell (self._step, self._block_multiplier, -1, self._filter_multiplier, self._filter_multiplier * 2, 2)
+                cell2_2 = cell (self._step, self._block_multiplier, -1, self._filter_multiplier * 2, self._filter_multiplier * 2, 1)
 
-                cell3 = cell (self._step, self._block_multiplier, -1,
-                              self._filter_multiplier * 2, None, None,
-                              self._filter_multiplier * 4)
+                cell3 = cell (self._step, self._block_multiplier, -1, self._filter_multiplier * 2, self._filter_multiplier * 4, 2)
 
-                self.cells += [cell1]
-                self.cells += [cell2]
+                self.cells += [cell1_1]
+                self.cells += [cell1_2]
+                self.cells += [cell2_1]
+                self.cells += [cell2_2]
                 self.cells += [cell3]
 
             elif i == 2 :
-                cell1 = cell (self._step, self._block_multiplier, self._filter_multiplier,
-                              None, self._filter_multiplier, self._filter_multiplier * 2,
-                              self._filter_multiplier)
+                cell1_1 = cell (self._step, self._block_multiplier, self._filter_multiplier, self._filter_multiplier, self._filter_multiplier, 1)
+                cell1_2 = cell (self._step, self._block_multiplier, self._filter_multiplier, self._filter_multiplier * 2, self._filter_multiplier, 0)
 
-                cell2 = cell (self._step, self._block_multiplier, self._filter_multiplier * 2,
-                              self._filter_multiplier, self._filter_multiplier * 2, self._filter_multiplier * 4,
-                              self._filter_multiplier * 2)
+                cell2_1 = cell (self._step, self._block_multiplier, self._filter_multiplier * 2, self._filter_multiplier, self._filter_multiplier * 2, 2)
+                cell2_2 = cell (self._step, self._block_multiplier, self._filter_multiplier * 2, self._filter_multiplier * 2, self._filter_multiplier * 2, 1)
+                cell2_3 = cell (self._step, self._block_multiplier, self._filter_multiplier * 2, self._filter_multiplier * 4, self._filter_multiplier * 2, 0)
 
-                cell3 = cell (self._step, self._block_multiplier, -1,
-                              self._filter_multiplier * 2, self._filter_multiplier * 4, None,
-                              self._filter_multiplier * 4)
 
-                cell4 = cell (self._step, self._block_multiplier, -1,
-                              self._filter_multiplier * 4, None, None,
-                              self._filter_multiplier * 8)
+                cell3_1 = cell (self._step, self._block_multiplier, -1, self._filter_multiplier * 2, self._filter_multiplier * 4, 2)
+                cell3_2 = cell (self._step, self._block_multiplier, -1, self._filter_multiplier * 4, self._filter_multiplier * 4, 1)
 
-                self.cells += [cell1]
-                self.cells += [cell2]
-                self.cells += [cell3]
+                cell4 = cell (self._step, self._block_multiplier, -1, self._filter_multiplier * 4, self._filter_multiplier * 8, 2)
+
+                self.cells += [cell1_1]
+                self.cells += [cell1_2]
+                self.cells += [cell2_1]
+                self.cells += [cell2_2]
+                self.cells += [cell2_3]
+                self.cells += [cell3_1]
+                self.cells += [cell3_2]
                 self.cells += [cell4]
 
 
 
             elif i == 3 :
-                cell1 = cell (self._step, self._block_multiplier, self._filter_multiplier,
-                              None, self._filter_multiplier, self._filter_multiplier * 2,
-                              self._filter_multiplier)
+                cell1_1 = cell (self._step, self._block_multiplier, self._filter_multiplier, self._filter_multiplier, self._filter_multiplier, 1)
+                cell1_2 = cell (self._step, self._block_multiplier, self._filter_multiplier, self._filter_multiplier * 2, self._filter_multiplier, 0)
 
-                cell2 = cell (self._step, self._block_multiplier, self._filter_multiplier * 2,
-                              self._filter_multiplier, self._filter_multiplier * 2, self._filter_multiplier * 4,
-                              self._filter_multiplier * 2)
-
-                cell3 = cell (self._step, self._block_multiplier, self._filter_multiplier * 4,
-                              self._filter_multiplier * 2, self._filter_multiplier * 4, self._filter_multiplier * 8,
-                              self._filter_multiplier * 4)
+                cell2_1 = cell (self._step, self._block_multiplier, self._filter_multiplier * 2, self._filter_multiplier, self._filter_multiplier * 2, 2)
+                cell2_2 = cell (self._step, self._block_multiplier, self._filter_multiplier * 2, self._filter_multiplier * 2, self._filter_multiplier * 2, 1)
+                cell2_3 = cell (self._step, self._block_multiplier, self._filter_multiplier * 2, self._filter_multiplier * 4, self._filter_multiplier * 2, 0)
 
 
-                cell4 = cell (self._step, self._block_multiplier, -1,
-                              self._filter_multiplier * 4, self._filter_multiplier * 8, None,
-                              self._filter_multiplier * 8)
+                cell3_1 = cell (self._step, self._block_multiplier, self._filter_multiplier * 4, self._filter_multiplier * 2, self._filter_multiplier * 4, 2)
+                cell3_2 = cell (self._step, self._block_multiplier, self._filter_multiplier * 4, self._filter_multiplier * 4, self._filter_multiplier * 4, 1)
+                cell3_3 = cell (self._step, self._block_multiplier, self._filter_multiplier * 4, self._filter_multiplier * 8, self._filter_multiplier * 4, 0)
 
-                self.cells += [cell1]
-                self.cells += [cell2]
-                self.cells += [cell3]
-                self.cells += [cell4]
+
+                cell4_1 = cell (self._step, self._block_multiplier, -1, self._filter_multiplier * 4, self._filter_multiplier * 8, 2)
+                cell4_2 = cell (self._step, self._block_multiplier, -1, self._filter_multiplier * 8, self._filter_multiplier * 8, 1)
+
+                self.cells += [cell1_1]
+                self.cells += [cell1_2]
+                self.cells += [cell2_1]
+                self.cells += [cell2_2]
+                self.cells += [cell2_3]
+                self.cells += [cell3_1]
+                self.cells += [cell3_2]
+                self.cells += [cell3_3]
+                self.cells += [cell4_1]
+                self.cells += [cell4_2]
 
             else :
-                cell1 = cell (self._step, self._block_multiplier, self._filter_multiplier,
-                                None, self._filter_multiplier, self._filter_multiplier * 2,
-                                self._filter_multiplier)
+                cell1_1 = cell (self._step, self._block_multiplier, self._filter_multiplier, self._filter_multiplier, self._filter_multiplier, 1)
+                cell1_2 = cell (self._step, self._block_multiplier, self._filter_multiplier, self._filter_multiplier * 2, self._filter_multiplier, 0)
 
-                cell2 = cell (self._step, self._block_multiplier, self._filter_multiplier * 2,
-                              self._filter_multiplier, self._filter_multiplier * 2, self._filter_multiplier * 4,
-                              self._filter_multiplier * 2)
+                cell2_1 = cell (self._step, self._block_multiplier, self._filter_multiplier * 2, self._filter_multiplier, self._filter_multiplier * 2, 2)
+                cell2_2 = cell (self._step, self._block_multiplier, self._filter_multiplier * 2, self._filter_multiplier * 2, self._filter_multiplier * 2, 1)
+                cell2_3 = cell (self._step, self._block_multiplier, self._filter_multiplier * 2, self._filter_multiplier * 4, self._filter_multiplier * 2, 0)
 
-                cell3 = cell (self._step, self._block_multiplier, self._filter_multiplier * 4,
-                                self._filter_multiplier * 2, self._filter_multiplier * 4, self._filter_multiplier * 8,
-                                self._filter_multiplier * 4)
 
-                cell4 = cell (self._step, self._block_multiplier, self._filter_multiplier * 8,
-                                self._filter_multiplier * 4, self._filter_multiplier * 8, None,
-                                self._filter_multiplier * 8)
+                cell3_1 = cell (self._step, self._block_multiplier, self._filter_multiplier * 4, self._filter_multiplier * 2, self._filter_multiplier * 4, 2)
+                cell3_2 = cell (self._step, self._block_multiplier, self._filter_multiplier * 4, self._filter_multiplier * 4, self._filter_multiplier * 4, 1)
+                cell3_3 = cell (self._step, self._block_multiplier, self._filter_multiplier * 4, self._filter_multiplier * 8, self._filter_multiplier * 4, 0)
 
-                self.cells += [cell1]
-                self.cells += [cell2]
-                self.cells += [cell3]
-                self.cells += [cell4]
 
+                cell4_1 = cell (self._step, self._block_multiplier, self._filter_multiplier * 8, self._filter_multiplier * 4, self._filter_multiplier * 8, 2)
+                cell4_2 = cell (self._step, self._block_multiplier, self._filter_multiplier * 8, self._filter_multiplier * 8, self._filter_multiplier * 8, 1)
+
+                self.cells += [cell1_1]
+                self.cells += [cell1_2]
+                self.cells += [cell2_1]
+                self.cells += [cell2_2]
+                self.cells += [cell2_3]
+                self.cells += [cell3_1]
+                self.cells += [cell3_2]
+                self.cells += [cell3_3]
+                self.cells += [cell4_1]
+                self.cells += [cell4_2]
         self.aspp_4 = nn.Sequential (
-            ASPP (self._block_multiplier * self._filter_multiplier, self._num_classes, 24, 24) #96 / 4 as in the paper
+            ASPP (self._block_multiplier * self._filter_multiplier, self._num_classes, 24, 24)
         )
         self.aspp_8 = nn.Sequential (
-            ASPP (self._block_multiplier * self._filter_multiplier * 2, self._num_classes, 12, 12) #96 / 8
+            ASPP (self._block_multiplier * self._filter_multiplier * 2, self._num_classes, 12, 12)
         )
         self.aspp_16 = nn.Sequential (
-            ASPP (self._block_multiplier * self._filter_multiplier * 4, self._num_classes, 6, 6) #96 / 16
+            ASPP (self._block_multiplier * self._filter_multiplier * 4, self._num_classes, 6, 6)
         )
         self.aspp_32 = nn.Sequential (
-            ASPP (self._block_multiplier * self._filter_multiplier * 8, self._num_classes, 3, 3) #96 / 32
+            ASPP (self._block_multiplier * self._filter_multiplier * 8, self._num_classes, 3, 3)
         )
 
 
@@ -163,52 +169,41 @@ class AutoDeeplab (nn.Module) :
         self.level_4.append (self.stem2 (self.level_2[-1]))
 
         count = 0
-
-        if torch.cuda.device_count() > 1:
-            img_device = torch.device('cuda', x.get_device())
-            normalized_alphas = F.softmax(self.alphas.to(device=img_device), dim=-1)
-            normalized_bottom_betas = F.softmax(self.bottom_betas.to(device=img_device), dim=-1)
-            normalized_betas8 = F.softmax(self.betas8.to(device=img_device), dim=-1)
-            normalized_betas16 = F.softmax(self.betas16.to(device=img_device), dim=-1)
-            normalized_top_betas = F.softmax(self.top_betas.to(device=img_device), dim=-1)
-        else:
-            normalized_alphas = F.softmax(self.alphas, dim=-1)
-            normalized_bottom_betas = F.softmax(self.bottom_betas, dim=-1)
-            normalized_betas8 = F.softmax (self.betas8, dim = -1)
-            normalized_betas16 = F.softmax(self.betas16, dim=-1)
-            normalized_top_betas = F.softmax(self.top_betas, dim=-1)
+        # img_device = torch.device('cuda', x.get_device())
+        # self.alphas_cell = self.alphas_cell.to(device=img_device)
+        # self.bottom_betas = self.bottom_betas.to(device=img_device)
+        # self.betas8 = self.betas8.to(device=img_device)
+        # self.betas16 = self.betas16.to(device=img_device)
+        # self.top_betas = self.top_betas.to(device=img_device)
+        normalized_alphas = F.softmax(self.alphas_cell, dim=-1)
+        normalized_bottom_betas = F.softmax(self.bottom_betas, dim=-1)
+        normalized_betas8 = F.softmax (self.betas8, dim = -1)
+        normalized_betas16 = F.softmax(self.betas16, dim=-1)
+        normalized_top_betas = F.softmax(self.top_betas, dim=-1)
         for layer in range (self._num_layers - 1) :
 
             if layer == 0 :
-                level4_new, = self.cells[count] (None, None, self.level_4[-1], None, normalized_alphas)
+                level4_new = self.cells[count] (None, self.level_4[-1], normalized_alphas)
                 count += 1
-                level8_new, = self.cells[count] (None, self.level_4[-1], None, None, normalized_alphas)
+                level8_new = self.cells[count] (None, self.level_4[-1], normalized_alphas)
                 count += 1
                 self.level_4.append (level4_new)
                 self.level_8.append (level8_new)
 
             elif layer == 1 :
-                level4_new_1, level4_new_2 = self.cells[count] (self.level_4[-2],
-                                                                None,
-                                                                self.level_4[-1],
-                                                                self.level_8[-1],
-                                                                normalized_alphas)
+                level4_new_1 = self.cells[count] (self.level_4[-2], self.level_4[-1], normalized_alphas)
+                count += 1
+                level4_new_2 = self.cells[count] (self.level_4[-2], self.level_8[-1], normalized_alphas)
                 count += 1
                 level4_new = normalized_bottom_betas[layer][0] * level4_new_1 + normalized_bottom_betas[layer][1] * level4_new_2
 
-                level8_new_1, level8_new_2 = self.cells[count] (None,
-                                                                self.level_4[-1],
-                                                                self.level_8[-1],
-                                                                None,
-                                                                normalized_alphas)
+                level8_new_1 = self.cells[count] (None, self.level_4[-1], normalized_alphas)
+                count += 1
+                level8_new_2 = self.cells[count] (None, self.level_8[-1], normalized_alphas)
                 count += 1
                 level8_new = normalized_top_betas[layer][0] * level8_new_1 + normalized_top_betas[layer][1] * level8_new_2
 
-                level16_new, = self.cells[count] (None,
-                                                  self.level_8[-1],
-                                                  None,
-                                                  None,
-                                                  normalized_alphas)
+                level16_new = self.cells[count] (None, self.level_8[-1], normalized_alphas)
                 level16_new = level16_new
                 count += 1
 
@@ -218,36 +213,29 @@ class AutoDeeplab (nn.Module) :
                 self.level_16.append (level16_new)
 
             elif layer == 2 :
-                level4_new_1, level4_new_2 = self.cells[count] (self.level_4[-2],
-                                                                None,
-                                                                self.level_4[-1],
-                                                                self.level_8[-1],
-                                                                normalized_alphas)
+                level4_new_1 = self.cells[count] (self.level_4[-2], self.level_4[-1], normalized_alphas)
+                count += 1
+                level4_new_2 = self.cells[count] (self.level_4[-2], self.level_8[-1], normalized_alphas)
                 count += 1
                 level4_new = normalized_bottom_betas[layer][0] * level4_new_1 + normalized_bottom_betas[layer][1] * level4_new_2
 
-                level8_new_1, level8_new_2, level8_new_3 = self.cells[count] (self.level_8[-2],
-                                                                              self.level_4[-1],
-                                                                              self.level_8[-1],
-                                                                              self.level_16[-1],
-                                                                              normalized_alphas)
+                level8_new_1 = self.cells[count] (self.level_8[-2], self.level_4[-1], normalized_alphas)
+                count += 1
+                level8_new_2 = self.cells[count] (self.level_8[-2], self.level_8[-1], normalized_alphas)
+                count += 1
+
+                level8_new_3 = self.cells[count] (self.level_8[-2], self.level_16[-1], normalized_alphas)
                 count += 1
                 level8_new = normalized_betas8[layer - 1][0] * level8_new_1 + normalized_betas8[layer - 1][1] * level8_new_2 + normalized_betas8[layer - 1][2] * level8_new_3
 
-                level16_new_1, level16_new_2 = self.cells[count] (None,
-                                                                  self.level_8[-1],
-                                                                  self.level_16[-1],
-                                                                  None,
-                                                                  normalized_alphas)
+                level16_new_1 = self.cells[count] (None, self.level_8[-1], normalized_alphas)
+                count += 1
+                level16_new_2 = self.cells[count] (None, self.level_16[-1], normalized_alphas)
                 count += 1
                 level16_new = normalized_top_betas[layer][0] * level16_new_1 + normalized_top_betas[layer][1] * level16_new_2
 
 
-                level32_new, = self.cells[count] (None,
-                                                  self.level_16[-1],
-                                                  None,
-                                                  None,
-                                                  normalized_alphas)
+                level32_new = self.cells[count] (None, self.level_16[-1], normalized_alphas)
                 level32_new = level32_new
                 count += 1
 
@@ -257,36 +245,32 @@ class AutoDeeplab (nn.Module) :
                 self.level_32.append (level32_new)
 
             elif layer == 3 :
-                level4_new_1, level4_new_2 = self.cells[count] (self.level_4[-2],
-                                                                None,
-                                                                self.level_4[-1],
-                                                                self.level_8[-1],
-                                                                normalized_alphas)
+                level4_new_1 = self.cells[count] (self.level_4[-2], self.level_4[-1], normalized_alphas)
+                count += 1
+                level4_new_2 = self.cells[count] (self.level_4[-2], self.level_8[-1], normalized_alphas)
                 count += 1
                 level4_new = normalized_bottom_betas[layer][0] * level4_new_1 + normalized_bottom_betas[layer][1] * level4_new_2
 
-                level8_new_1, level8_new_2, level8_new_3 = self.cells[count] (self.level_8[-2],
-                                                                              self.level_4[-1],
-                                                                              self.level_8[-1],
-                                                                              self.level_16[-1],
-                                                                              normalized_alphas)
+                level8_new_1 = self.cells[count] (self.level_8[-2], self.level_4[-1], normalized_alphas)
+                count += 1
+                level8_new_2 = self.cells[count] (self.level_8[-2], self.level_8[-1], normalized_alphas)
+                count += 1
+                level8_new_3 = self.cells[count] (self.level_8[-2], self.level_16[-1], normalized_alphas)
                 count += 1
                 level8_new = normalized_betas8[layer - 1][0] * level8_new_1 + normalized_betas8[layer - 1][1] * level8_new_2 + normalized_betas8[layer - 1][2] * level8_new_3
 
-                level16_new_1, level16_new_2, level16_new_3 = self.cells[count] (self.level_16[-2],
-                                                                                 self.level_8[-1],
-                                                                                 self.level_16[-1],
-                                                                                 self.level_32[-1],
-                                                                                 normalized_alphas)
+                level16_new_1 = self.cells[count] (self.level_16[-2], self.level_8[-1], normalized_alphas)
+                count += 1
+                level16_new_2 = self.cells[count] (self.level_16[-2], self.level_16[-1], normalized_alphas)
+                count += 1
+                level16_new_3 = self.cells[count] (self.level_16[-2], self.level_32[-1], normalized_alphas)
                 count += 1
                 level16_new = normalized_betas16[layer - 2][0] * level16_new_1 + normalized_betas16[layer - 2][1] * level16_new_2 + normalized_betas16[layer - 2][2] * level16_new_3
 
 
-                level32_new_1, level32_new_2 = self.cells[count] (None,
-                                                                  self.level_16[-1],
-                                                                  self.level_32[-1],
-                                                                  None,
-                                                                  normalized_alphas)
+                level32_new_1 = self.cells[count] (None, self.level_16[-1], normalized_alphas)
+                count += 1
+                level32_new_2 = self.cells[count] (None, self.level_32[-1], normalized_alphas)
                 count += 1
                 level32_new = normalized_top_betas[layer][0] * level32_new_1 + normalized_top_betas[layer][1] * level32_new_2
 
@@ -298,37 +282,32 @@ class AutoDeeplab (nn.Module) :
 
 
             else :
-                level4_new_1, level4_new_2 = self.cells[count] (self.level_4[-2],
-                                                  None,
-                                                  self.level_4[-1],
-                                                  self.level_8[-1],
-                                                  normalized_alphas)
+                level4_new_1 = self.cells[count] (self.level_4[-2], self.level_4[-1], normalized_alphas)
+                count += 1
+                level4_new_2 = self.cells[count] (self.level_4[-2], self.level_8[-1], normalized_alphas)
                 count += 1
                 level4_new = normalized_bottom_betas[layer][0] * level4_new_1 + normalized_bottom_betas[layer][1] * level4_new_2
 
-                level8_new_1, level8_new_2, level8_new_3 = self.cells[count] (self.level_8[-2],
-                                                                              self.level_4[-1],
-                                                                              self.level_8[-1],
-                                                                              self.level_16[-1],
-                                                                              normalized_alphas)
+                level8_new_1 = self.cells[count] (self.level_8[-2], self.level_4[-1], normalized_alphas)
                 count += 1
-
+                level8_new_2 = self.cells[count] (self.level_8[-2], self.level_8[-1], normalized_alphas)
+                count += 1
+                level8_new_3 = self.cells[count] (self.level_8[-2], self.level_16[-1], normalized_alphas)
+                count += 1
                 level8_new = normalized_betas8[layer - 1][0] * level8_new_1 + normalized_betas8[layer - 1][1] * level8_new_2 + normalized_betas8[layer - 1][2] * level8_new_3
 
-                level16_new_1, layer16_new_2, layer16_new_3 = self.cells[count] (self.level_16[-2],
-                                                                                 self.level_8[-1],
-                                                                                 self.level_16[-1],
-                                                                                 self.level_32[-1],
-                                                                                 normalized_alphas)
+                level16_new_1 = self.cells[count] (self.level_16[-2], self.level_8[-1], normalized_alphas)
+                count += 1
+                level16_new_2 = self.cells[count] (self.level_16[-2], self.level_16[-1], normalized_alphas)
+                count += 1
+                level16_new_3 = self.cells[count] (self.level_16[-2], self.level_32[-1], normalized_alphas)
                 count += 1
                 level16_new = normalized_betas16[layer - 2][0] * level16_new_1 + normalized_betas16[layer - 2][1] * level16_new_2 + normalized_betas16[layer - 2][2] * level16_new_3
 
 
-                level32_new_1, level32_new_2 = self.cells[count] (self.level_32[-2],
-                                                                  self.level_16[-1],
-                                                                  self.level_32[-1],
-                                                                  None,
-                                                                  normalized_alphas)
+                level32_new_1 = self.cells[count] (self.level_32[-2], self.level_16[-1], normalized_alphas)
+                count += 1
+                level32_new_2 = self.cells[count] (self.level_32[-2], self.level_32[-1], normalized_alphas)
                 count += 1
                 level32_new = normalized_top_betas[layer][0] * level32_new_1 + normalized_top_betas[layer][1] * level32_new_2
 
@@ -357,27 +336,32 @@ class AutoDeeplab (nn.Module) :
     def _initialize_alphas_betas(self):
         k = sum(1 for i in range(self._step) for n in range(2+i))
         num_ops = len(PRIMITIVES)
-        alphas = torch.tensor (1e-3*torch.randn(k, num_ops).cuda(), requires_grad=True)
-        bottom_betas = torch.tensor (1e-3 * torch.randn(self._num_layers - 1, 2).cuda(), requires_grad=True)
-        betas8 = torch.tensor (1e-3 * torch.randn(self._num_layers - 2, 3).cuda(), requires_grad=True)
-        betas16 = torch.tensor(1e-3 * torch.randn(self._num_layers - 3, 3).cuda(), requires_grad=True)
-        top_betas = torch.tensor (1e-3 * torch.randn(self._num_layers - 1, 2).cuda(), requires_grad=True)
+        self.alphas_cell = (1e-3 * torch.randn(k, num_ops)).cuda().clone().detach().requires_grad_(True)
+        self.bottom_betas = (1e-3 * torch.randn(self._num_layers - 1, 2)).cuda().clone().detach().requires_grad_(True)
+        self.betas8 = (1e-3 * torch.randn(self._num_layers - 2, 3)).cuda().clone().detach().requires_grad_(True)
+        self.betas16 = (1e-3 * torch.randn(self._num_layers - 3, 3)).cuda().clone().detach().requires_grad_(True)
+        self.top_betas = (1e-3 * torch.randn(self._num_layers - 1, 2)).cuda().clone().detach().requires_grad_(True)
+
+        # self.alphas_cell.to(dtype=torch.float16)
+        # self.bottom_betas.to(dtype=torch.float16)
+        # self.betas8.to(dtype=torch.float16)
+        # self.betas16.to(dtype=torch.float16)
+        # self.top_betas.to(dtype=torch.float16)
+
+        # self.alphas_cell = torch.tensor (1e-3*torch.randn(k, num_ops).cuda(), requires_grad=True)
+        # self.bottom_betas = torch.tensor (1e-3 * torch.randn(self._num_layers - 1, 2).cuda(), requires_grad=True)
+        # self.betas8 = torch.tensor (1e-3 * torch.randn(self._num_layers - 2, 3).cuda(), requires_grad=True)
+        # self.betas16 = torch.tensor(1e-3 * torch.randn(self._num_layers - 3, 3).cuda(), requires_grad=True)
+        # self.top_betas = torch.tensor (1e-3 * torch.randn(self._num_layers - 1, 2).cuda(), requires_grad=True)
 
         self._arch_parameters = [
-            alphas,
-            bottom_betas,
-            betas8,
-            betas16,
-            top_betas,
+            self.alphas_cell,
+            self.bottom_betas,
+            self.betas8,
+            self.betas16,
+            self.top_betas,
         ]
-        self._arch_param_names = [
-            'alphas',
-            'bottom_betas',
-            'betas8',
-            'betas16',
-            'top_betas']
 
-        [self.register_parameter(name, torch.nn.Parameter(param)) for name, param in zip(self._arch_param_names, self._arch_parameters)]
 
     def decode_viterbi(self):
         decoder = Decoder(self.bottom_betas, self.betas8, self.betas16, self.top_betas)
@@ -388,14 +372,35 @@ class AutoDeeplab (nn.Module) :
         return decoder.dfs_decode()
 
     def arch_parameters (self) :
-        return [param for name, param in self.named_parameters() if name in self._arch_param_names]
-
-    def weight_parameters(self):
-        return [param for name, param in self.named_parameters() if name not in self._arch_param_names]
+        return self._arch_parameters
 
     def genotype(self):
-        decoder = Decoder(self.alphas_cell, self._block_multiplier, self._step)
-        return decoder.genotype_decode()
+        def _parse(weights):
+            gene = []
+            n = 2
+            start = 0
+            for i in range(self._step):
+                end = start + n
+                W = weights[start:end].copy()
+                edges = sorted (range(i + 2), key=lambda x: -max(W[x][k] for k in range(len(W[x])) if k != PRIMITIVES.index('none')))[:2]
+                for j in edges:
+                    k_best = None
+                    for k in range(len(W[j])):
+                        if k != PRIMITIVES.index('none'):
+                            if k_best is None or W[j][k] > W[j][k_best]:
+                                k_best = k
+                    gene.append((PRIMITIVES[k_best], j))
+                start = end
+                n += 1
+            return gene
+
+        gene_cell = _parse(F.softmax(self.alphas_cell, dim=-1).data.cpu().numpy())
+        concat = range(2 + self._step - self._block_multiplier, self._step + 2)
+        genotype = Genotype(
+            cell=gene_cell, cell_concat=concat
+        )
+
+        return genotype
 
     def _loss (self, input, target) :
         logits = self (input)

--- a/summaries.py
+++ b/summaries.py
@@ -1,0 +1,23 @@
+import os
+import torch
+from torchvision.utils import make_grid
+from tensorboardX import SummaryWriter
+from dataloaders.utils import decode_seg_map_sequence
+
+class TensorboardSummary(object):
+    def __init__(self, directory):
+        self.directory = directory
+
+    def create_summary(self):
+        writer = SummaryWriter(log_dir=os.path.join(self.directory))
+        return writer
+
+    def visualize_image(self, writer, dataset, image, target, output, global_step):
+        grid_image = make_grid(image[:3].clone().cpu().data, 3, normalize=True)
+        writer.add_image('Image', grid_image, global_step)
+        grid_image = make_grid(decode_seg_map_sequence(torch.max(output[:3], 1)[1].detach().cpu().numpy(),
+                                                       dataset=dataset), 3, normalize=False, range=(0, 255))
+        writer.add_image('Predicted label', grid_image, global_step)
+        grid_image = make_grid(decode_seg_map_sequence(torch.squeeze(target[:3], 1).detach().cpu().numpy(),
+                                                       dataset=dataset), 3, normalize=False, range=(0, 255))
+        writer.add_image('Groundtruth label', grid_image, global_step)

--- a/train_autodeeplab.py
+++ b/train_autodeeplab.py
@@ -61,7 +61,7 @@ class Trainer(object):
         # Define network
         model = AutoDeeplab (num_classes=self.nclass, num_layers=12, criterion=self.criterion, filter_multiplier=self.args.filter_multiplier)
         optimizer = torch.optim.SGD(
-                model.parameters(),
+                model.weight_parameters(),
                 args.lr,
                 momentum=args.momentum,
                 weight_decay=args.weight_decay

--- a/train_autodeeplab.py
+++ b/train_autodeeplab.py
@@ -285,7 +285,7 @@ def main():
                         help='opt level for half percision training (default: 01)')
     parser.add_argument('--out-stride', type=int, default=16,
                         help='network output stride (default: 8)')
-    parser.add_argument('--dataset', type=str, default='kd',
+    parser.add_argument('--dataset', type=str, default='cityscapes',
                         choices=['pascal', 'coco', 'cityscapes', 'kd'],
                         help='dataset name (default: pascal)')
     parser.add_argument('--autodeeplab', type=str, default='search',

--- a/utils/summaries.py
+++ b/utils/summaries.py
@@ -9,7 +9,7 @@ class TensorboardSummary(object):
         self.directory = directory
 
     def create_summary(self):
-        writer = SummaryWriter(logdir=os.path.join(self.directory))
+        writer = SummaryWriter(log_dir=os.path.join(self.directory))
         return writer
 
     def visualize_image(self, writer, dataset, image, target, output, global_step):


### PR DESCRIPTION
Hi,
made some changes to enable half precision training in order to reduce memory consumption.

**some restrictions:**
_on single GPU -_ 
if working with pytorch version 1.1 opt_level 'O1' produces an error, so it's best to work with opt_level 'O2' (it also saves more memory)
i also tested with pytorch built from source after merging the changes from [this PR](https://github.com/pytorch/pytorch/pull/22750) - then all opt_level work properly

_on multiple GPU -_ 
need to use the pytorch version built from source and then opt_level 'O1' will work, other opt_level still don't play nicely with multi-gpu.

i tested with the following parameters - 
--backbone=xception --out-stride=16 --dataset=cityscapes --gpu-ids=0 --resize=512 --base_size=320 --crop_size=320 --batch-size=2 --filter_multiplier=4 --workers=4 --opt_level=O2