### PR TITLE
Remove the use of lists in forward()

### DIFF
--- a/auto_deeplab.py
+++ b/auto_deeplab.py
@@ -161,7 +161,7 @@ class AutoDeeplab (nn.Module) :
         temp = self.stem0 (x)
         self.level_2.append (self.stem1 (temp))
         self.level_4.append (self.stem2 (self.level_2[-1]))
-
+    
         count = 0
 
         if torch.cuda.device_count() > 1:

--- a/auto_deeplab.py
+++ b/auto_deeplab.py
@@ -38,103 +38,73 @@ class AutoDeeplab (nn.Module) :
 
         #C_prev_prev = 64
         intitial_fm = C_initial / self._block_multiplier
-        for i in range (self._num_layers) :
+
+        ### init the self.cells array
+
+        # layer == 0:
+
+        self.cells += [cell (self._step, self._block_multiplier, -1,
+                             None, intitial_fm, None, self._filter_multiplier)]
+        self.cells += [cell (self._step, self._block_multiplier, -1,
+                             intitial_fm, None, None, self._filter_multiplier * 2)]
+
+        # layer == 1:
+
+        self.cells += [cell (self._step, self._block_multiplier, intitial_fm,
+                             None, self._filter_multiplier, self._filter_multiplier * 2, self._filter_multiplier)]
+        self.cells += [cell (self._step, self._block_multiplier, -1,
+                             self._filter_multiplier, self._filter_multiplier * 2, None, self._filter_multiplier * 2)]
+        self.cells += [cell (self._step, self._block_multiplier, -1,
+                             self._filter_multiplier * 2, None, None, self._filter_multiplier * 4)]
+
+        # layer == 2:
+
+        self.cells += [cell (self._step, self._block_multiplier, self._filter_multiplier,
+                              None, self._filter_multiplier, self._filter_multiplier * 2,
+                              self._filter_multiplier)]
+        self.cells += [cell (self._step, self._block_multiplier, self._filter_multiplier * 2,
+                              self._filter_multiplier, self._filter_multiplier * 2, self._filter_multiplier * 4,
+                              self._filter_multiplier * 2)]
+        self.cells += [cell (self._step, self._block_multiplier, -1,
+                              self._filter_multiplier * 2, self._filter_multiplier * 4, None,
+                              self._filter_multiplier * 4)]
+        self.cells += [cell (self._step, self._block_multiplier, -1,
+                              self._filter_multiplier * 4, None, None,
+                              self._filter_multiplier * 8)]
+
+        # layer == 3:
+
+        self.cells += [cell (self._step, self._block_multiplier, self._filter_multiplier,
+                              None, self._filter_multiplier, self._filter_multiplier * 2,
+                              self._filter_multiplier)]
+        self.cells += [cell (self._step, self._block_multiplier, self._filter_multiplier * 2,
+                              self._filter_multiplier, self._filter_multiplier * 2, self._filter_multiplier * 4,
+                              self._filter_multiplier * 2)]
+        self.cells += [cell (self._step, self._block_multiplier, self._filter_multiplier * 4,
+                              self._filter_multiplier * 2, self._filter_multiplier * 4, self._filter_multiplier * 8,
+                              self._filter_multiplier * 4)]
+        self.cells += [cell (self._step, self._block_multiplier, -1,
+                              self._filter_multiplier * 4, self._filter_multiplier * 8, None,
+                              self._filter_multiplier * 8)]
+
+        # layer > 3:
+
+        self.cells += [cell(self._step, self._block_multiplier, self._filter_multiplier,
+                            None, self._filter_multiplier, self._filter_multiplier * 2,
+                            self._filter_multiplier)]
+        self.cells += [cell(self._step, self._block_multiplier, self._filter_multiplier * 2,
+                            self._filter_multiplier, self._filter_multiplier * 2, self._filter_multiplier * 4,
+                            self._filter_multiplier * 2)]
+        self.cells += [cell(self._step, self._block_multiplier, self._filter_multiplier * 4,
+                            self._filter_multiplier * 2, self._filter_multiplier * 4, self._filter_multiplier * 8,
+                            self._filter_multiplier * 4)]
+        self.cells += [cell(self._step, self._block_multiplier, self._filter_multiplier * 8,
+                            self._filter_multiplier * 4, self._filter_multiplier * 8, None,
+                            self._filter_multiplier * 8)]
+
+        # for i in range (4, self._num_layers) :
         # def __init__(self, steps, multiplier, C_prev_prev, C_initial, C, rate) : rate = 0 , 1, 2  reduce rate
 
-            if i == 0 :
-                cell1 = cell (self._step, self._block_multiplier, -1,
-                              None, intitial_fm, None,
-                              self._filter_multiplier)
-                cell2 = cell (self._step, self._block_multiplier, -1,
-                              intitial_fm, None, None,
-                              self._filter_multiplier * 2)
-                self.cells += [cell1]
-                self.cells += [cell2]
-            elif i == 1 :
-                cell1 = cell (self._step, self._block_multiplier, intitial_fm,
-                              None, self._filter_multiplier, self._filter_multiplier * 2,
-                              self._filter_multiplier)
-
-                cell2 = cell (self._step, self._block_multiplier, -1,
-                              self._filter_multiplier, self._filter_multiplier * 2, None,
-                              self._filter_multiplier * 2)
-
-                cell3 = cell (self._step, self._block_multiplier, -1,
-                              self._filter_multiplier * 2, None, None,
-                              self._filter_multiplier * 4)
-
-                self.cells += [cell1]
-                self.cells += [cell2]
-                self.cells += [cell3]
-
-            elif i == 2 :
-                cell1 = cell (self._step, self._block_multiplier, self._filter_multiplier,
-                              None, self._filter_multiplier, self._filter_multiplier * 2,
-                              self._filter_multiplier)
-
-                cell2 = cell (self._step, self._block_multiplier, self._filter_multiplier * 2,
-                              self._filter_multiplier, self._filter_multiplier * 2, self._filter_multiplier * 4,
-                              self._filter_multiplier * 2)
-
-                cell3 = cell (self._step, self._block_multiplier, -1,
-                              self._filter_multiplier * 2, self._filter_multiplier * 4, None,
-                              self._filter_multiplier * 4)
-
-                cell4 = cell (self._step, self._block_multiplier, -1,
-                              self._filter_multiplier * 4, None, None,
-                              self._filter_multiplier * 8)
-
-                self.cells += [cell1]
-                self.cells += [cell2]
-                self.cells += [cell3]
-                self.cells += [cell4]
-
-
-
-            elif i == 3 :
-                cell1 = cell (self._step, self._block_multiplier, self._filter_multiplier,
-                              None, self._filter_multiplier, self._filter_multiplier * 2,
-                              self._filter_multiplier)
-
-                cell2 = cell (self._step, self._block_multiplier, self._filter_multiplier * 2,
-                              self._filter_multiplier, self._filter_multiplier * 2, self._filter_multiplier * 4,
-                              self._filter_multiplier * 2)
-
-                cell3 = cell (self._step, self._block_multiplier, self._filter_multiplier * 4,
-                              self._filter_multiplier * 2, self._filter_multiplier * 4, self._filter_multiplier * 8,
-                              self._filter_multiplier * 4)
-
-
-                cell4 = cell (self._step, self._block_multiplier, -1,
-                              self._filter_multiplier * 4, self._filter_multiplier * 8, None,
-                              self._filter_multiplier * 8)
-
-                self.cells += [cell1]
-                self.cells += [cell2]
-                self.cells += [cell3]
-                self.cells += [cell4]
-
-            else :
-                cell1 = cell (self._step, self._block_multiplier, self._filter_multiplier,
-                                None, self._filter_multiplier, self._filter_multiplier * 2,
-                                self._filter_multiplier)
-
-                cell2 = cell (self._step, self._block_multiplier, self._filter_multiplier * 2,
-                              self._filter_multiplier, self._filter_multiplier * 2, self._filter_multiplier * 4,
-                              self._filter_multiplier * 2)
-
-                cell3 = cell (self._step, self._block_multiplier, self._filter_multiplier * 4,
-                                self._filter_multiplier * 2, self._filter_multiplier * 4, self._filter_multiplier * 8,
-                                self._filter_multiplier * 4)
-
-                cell4 = cell (self._step, self._block_multiplier, self._filter_multiplier * 8,
-                                self._filter_multiplier * 4, self._filter_multiplier * 8, None,
-                                self._filter_multiplier * 8)
-
-                self.cells += [cell1]
-                self.cells += [cell2]
-                self.cells += [cell3]
-                self.cells += [cell4]
 
         self.aspp_4 = nn.Sequential (
             ASPP (self._block_multiplier * self._filter_multiplier, self._num_classes, 24, 24) #96 / 4 as in the paper
@@ -149,20 +119,16 @@ class AutoDeeplab (nn.Module) :
             ASPP (self._block_multiplier * self._filter_multiplier * 8, self._num_classes, 3, 3) #96 / 32
         )
 
-
-
     def forward (self, x) :
         # self._init_level_arr (x)
-        self.level_2 = []
-        self.level_4 = []
-        self.level_8 = []
-        self.level_16 = []
-        self.level_32 = []
-        temp = self.stem0 (x)
-        self.level_2.append (self.stem1 (temp))
-        self.level_4.append (self.stem2 (self.level_2[-1]))
+        cell = cell_level_search.Cell
+        C_initial = 128
+        intitial_fm = C_initial / self._block_multiplier
 
-        count = 0
+        level_2_curr = self.stem1 (self.stem0 (x))
+        level_4_curr = self.stem2 (level_2_curr)
+
+        # del level_2_curr
 
         if torch.cuda.device_count() > 1:
             img_device = torch.device('cuda', x.get_device())
@@ -177,171 +143,236 @@ class AutoDeeplab (nn.Module) :
             normalized_betas8 = F.softmax (self.betas8, dim = -1)
             normalized_betas16 = F.softmax(self.betas16, dim=-1)
             normalized_top_betas = F.softmax(self.top_betas, dim=-1)
-        for layer in range (self._num_layers - 1) :
-
-            if layer == 0 :
-                level4_new, = self.cells[count] (None, None, self.level_4[-1], None, normalized_alphas)
-                count += 1
-                level8_new, = self.cells[count] (None, self.level_4[-1], None, None, normalized_alphas)
-                count += 1
-                self.level_4.append (level4_new)
-                self.level_8.append (level8_new)
-
-            elif layer == 1 :
-                level4_new_1, level4_new_2 = self.cells[count] (self.level_4[-2],
-                                                                None,
-                                                                self.level_4[-1],
-                                                                self.level_8[-1],
-                                                                normalized_alphas)
-                count += 1
-                level4_new = normalized_bottom_betas[layer][0] * level4_new_1 + normalized_bottom_betas[layer][1] * level4_new_2
-
-                level8_new_1, level8_new_2 = self.cells[count] (None,
-                                                                self.level_4[-1],
-                                                                self.level_8[-1],
-                                                                None,
-                                                                normalized_alphas)
-                count += 1
-                level8_new = normalized_top_betas[layer][0] * level8_new_1 + normalized_top_betas[layer][1] * level8_new_2
-
-                level16_new, = self.cells[count] (None,
-                                                  self.level_8[-1],
-                                                  None,
-                                                  None,
-                                                  normalized_alphas)
-                level16_new = level16_new
-                count += 1
 
 
-                self.level_4.append (level4_new)
-                self.level_8.append (level8_new)
-                self.level_16.append (level16_new)
+        # layer == 0 :
 
-            elif layer == 2 :
-                level4_new_1, level4_new_2 = self.cells[count] (self.level_4[-2],
-                                                                None,
-                                                                self.level_4[-1],
-                                                                self.level_8[-1],
-                                                                normalized_alphas)
-                count += 1
-                level4_new = normalized_bottom_betas[layer][0] * level4_new_1 + normalized_bottom_betas[layer][1] * level4_new_2
+        cell_curr = cell (self._step, self._block_multiplier, -1,
+                             None, intitial_fm, None, self._filter_multiplier)
+        level4_new, = self.cells[0] (None, None, level_4_curr, None, normalized_alphas)
+        level8_new, = self.cells[1] (None, level_4_curr, None, None, normalized_alphas)
 
-                level8_new_1, level8_new_2, level8_new_3 = self.cells[count] (self.level_8[-2],
-                                                                              self.level_4[-1],
-                                                                              self.level_8[-1],
-                                                                              self.level_16[-1],
-                                                                              normalized_alphas)
-                count += 1
-                level8_new = normalized_betas8[layer - 1][0] * level8_new_1 + normalized_betas8[layer - 1][1] * level8_new_2 + normalized_betas8[layer - 1][2] * level8_new_3
+        level_4_prev = level_4_curr
+        level_4_curr = level4_new
+        level_8_curr = level8_new
 
-                level16_new_1, level16_new_2 = self.cells[count] (None,
-                                                                  self.level_8[-1],
-                                                                  self.level_16[-1],
-                                                                  None,
-                                                                  normalized_alphas)
-                count += 1
-                level16_new = normalized_top_betas[layer][0] * level16_new_1 + normalized_top_betas[layer][1] * level16_new_2
+        # layer == 1 :
 
+        level4_new_1, level4_new_2 = self.cells[2] (level_4_prev,
+                                                        None,
+                                                        level_4_curr,
+                                                        level_8_curr,
+                                                        normalized_alphas)
 
-                level32_new, = self.cells[count] (None,
-                                                  self.level_16[-1],
-                                                  None,
-                                                  None,
-                                                  normalized_alphas)
-                level32_new = level32_new
-                count += 1
+        level4_new = normalized_bottom_betas[1][0] * level4_new_1 + normalized_bottom_betas[1][1] * level4_new_2
 
-                self.level_4.append (level4_new)
-                self.level_8.append (level8_new)
-                self.level_16.append (level16_new)
-                self.level_32.append (level32_new)
+        # del level4_new_1
+        # del level4_new_2
 
-            elif layer == 3 :
-                level4_new_1, level4_new_2 = self.cells[count] (self.level_4[-2],
-                                                                None,
-                                                                self.level_4[-1],
-                                                                self.level_8[-1],
-                                                                normalized_alphas)
-                count += 1
-                level4_new = normalized_bottom_betas[layer][0] * level4_new_1 + normalized_bottom_betas[layer][1] * level4_new_2
+        level8_new_1, level8_new_2 = self.cells[3] (None,
+                                                        level_4_curr,
+                                                        level_8_curr,
+                                                        None,
+                                                        normalized_alphas)
 
-                level8_new_1, level8_new_2, level8_new_3 = self.cells[count] (self.level_8[-2],
-                                                                              self.level_4[-1],
-                                                                              self.level_8[-1],
-                                                                              self.level_16[-1],
-                                                                              normalized_alphas)
-                count += 1
-                level8_new = normalized_betas8[layer - 1][0] * level8_new_1 + normalized_betas8[layer - 1][1] * level8_new_2 + normalized_betas8[layer - 1][2] * level8_new_3
+        level8_new = normalized_top_betas[1][0] * level8_new_1 + normalized_top_betas[1][1] * level8_new_2
 
-                level16_new_1, level16_new_2, level16_new_3 = self.cells[count] (self.level_16[-2],
-                                                                                 self.level_8[-1],
-                                                                                 self.level_16[-1],
-                                                                                 self.level_32[-1],
-                                                                                 normalized_alphas)
-                count += 1
-                level16_new = normalized_betas16[layer - 2][0] * level16_new_1 + normalized_betas16[layer - 2][1] * level16_new_2 + normalized_betas16[layer - 2][2] * level16_new_3
+        # del level8_new_1
+        # del level8_new_2
 
+        level16_new, = self.cells[4] (None,
+                                          level_8_curr,
+                                          None,
+                                          None,
+                                          normalized_alphas)
+        # level16_new = level16_new
 
-                level32_new_1, level32_new_2 = self.cells[count] (None,
-                                                                  self.level_16[-1],
-                                                                  self.level_32[-1],
-                                                                  None,
-                                                                  normalized_alphas)
-                count += 1
-                level32_new = normalized_top_betas[layer][0] * level32_new_1 + normalized_top_betas[layer][1] * level32_new_2
+        level_4_prev = level_4_curr
+        level_4_curr = level4_new
 
+        level_8_prev = level_8_curr
+        level_8_curr = level8_new
 
-                self.level_4.append (level4_new)
-                self.level_8.append (level8_new)
-                self.level_16.append (level16_new)
-                self.level_32.append (level32_new)
+        level_16_curr = level16_new
 
+        # layer == 2 :
 
-            else :
-                level4_new_1, level4_new_2 = self.cells[count] (self.level_4[-2],
-                                                  None,
-                                                  self.level_4[-1],
-                                                  self.level_8[-1],
-                                                  normalized_alphas)
-                count += 1
-                level4_new = normalized_bottom_betas[layer][0] * level4_new_1 + normalized_bottom_betas[layer][1] * level4_new_2
+        level4_new_1, level4_new_2 = self.cells[5] (level_4_prev,
+                                                        None,
+                                                        level_4_curr,
+                                                        level_8_curr,
+                                                        normalized_alphas)
 
-                level8_new_1, level8_new_2, level8_new_3 = self.cells[count] (self.level_8[-2],
-                                                                              self.level_4[-1],
-                                                                              self.level_8[-1],
-                                                                              self.level_16[-1],
-                                                                              normalized_alphas)
-                count += 1
+        level4_new = normalized_bottom_betas[2][0] * level4_new_1 + normalized_bottom_betas[2][1] * level4_new_2
 
-                level8_new = normalized_betas8[layer - 1][0] * level8_new_1 + normalized_betas8[layer - 1][1] * level8_new_2 + normalized_betas8[layer - 1][2] * level8_new_3
+        # del level4_new_1
+        # del level4_new_2
 
-                level16_new_1, layer16_new_2, layer16_new_3 = self.cells[count] (self.level_16[-2],
-                                                                                 self.level_8[-1],
-                                                                                 self.level_16[-1],
-                                                                                 self.level_32[-1],
-                                                                                 normalized_alphas)
-                count += 1
-                level16_new = normalized_betas16[layer - 2][0] * level16_new_1 + normalized_betas16[layer - 2][1] * level16_new_2 + normalized_betas16[layer - 2][2] * level16_new_3
+        level8_new_1, level8_new_2, level8_new_3 = self.cells[6] (level_8_prev,
+                                                                      level_4_curr,
+                                                                      level_8_curr,
+                                                                      level_16_curr,
+                                                                      normalized_alphas)
 
+        level8_new = normalized_betas8[2 - 1][0] * level8_new_1 + normalized_betas8[2 - 1][1] * level8_new_2 + normalized_betas8[2 - 1][2] * level8_new_3
 
-                level32_new_1, level32_new_2 = self.cells[count] (self.level_32[-2],
-                                                                  self.level_16[-1],
-                                                                  self.level_32[-1],
-                                                                  None,
-                                                                  normalized_alphas)
-                count += 1
-                level32_new = normalized_top_betas[layer][0] * level32_new_1 + normalized_top_betas[layer][1] * level32_new_2
+        # del level8_new_1
+        # del level8_new_2
+        # del level8_new_3
 
+        level16_new_1, level16_new_2 = self.cells[7] (None,
+                                                          level_8_curr,
+                                                          level_16_curr,
+                                                          None,
+                                                          normalized_alphas)
 
-                self.level_4.append (level4_new)
-                self.level_8.append (level8_new)
-                self.level_16.append (level16_new)
-                self.level_32.append (level32_new)
+        level16_new = normalized_top_betas[2][0] * level16_new_1 + normalized_top_betas[2][1] * level16_new_2
 
-        aspp_result_4 = self.aspp_4 (self.level_4[-1])
-        aspp_result_8 = self.aspp_8 (self.level_8[-1])
-        aspp_result_16 = self.aspp_16 (self.level_16[-1])
-        aspp_result_32 = self.aspp_32 (self.level_32[-1])
+        # del level16_new_1
+        # del level16_new_2
+
+        level32_new, = self.cells[8] (None,
+                                          level_16_curr,
+                                          None,
+                                          None,
+                                          normalized_alphas)
+
+        level_4_prev = level_4_curr
+        level_4_curr = level4_new
+
+        level_8_prev = level_8_curr
+        level_8_curr = level8_new
+
+        level_16_prev = level_16_curr
+        level_16_curr = level16_new
+
+        level_32_curr = level32_new
+
+        # layer == 3 :
+
+        level4_new_1, level4_new_2 = self.cells[9] (level_4_prev,
+                                                        None,
+                                                        level_4_curr,
+                                                        level_8_curr,
+                                                        normalized_alphas)
+
+        level4_new = normalized_bottom_betas[3][0] * level4_new_1 + normalized_bottom_betas[3][1] * level4_new_2
+
+        # del level4_new_1
+        # del level4_new_2
+
+        level8_new_1, level8_new_2, level8_new_3 = self.cells[10] (level_8_prev,
+                                                                      level_4_curr,
+                                                                      level_8_curr,
+                                                                      level_16_curr,
+                                                                      normalized_alphas)
+
+        level8_new = normalized_betas8[3 - 1][0] * level8_new_1 + normalized_betas8[3 - 1][1] * level8_new_2 + normalized_betas8[3 - 1][2] * level8_new_3
+
+        # del level8_new_1
+        # del level8_new_2
+        # del level8_new_3
+
+        level16_new_1, level16_new_2, level16_new_3 = self.cells[11] (level_16_prev,
+                                                                         level_8_curr,
+                                                                         level_16_curr,
+                                                                         level_32_curr,
+                                                                         normalized_alphas)
+
+        level16_new = normalized_betas16[3 - 2][0] * level16_new_1 + normalized_betas16[3 - 2][1] * level16_new_2 + normalized_betas16[3 - 2][2] * level16_new_3
+
+        # del level16_new_1
+        # del level16_new_2
+        # del level16_new_3
+
+        level32_new_1, level32_new_2 = self.cells[12] (None,
+                                                          level_16_curr,
+                                                          level_32_curr,
+                                                          None,
+                                                          normalized_alphas)
+
+        level32_new = normalized_top_betas[3][0] * level32_new_1 + normalized_top_betas[3][1] * level32_new_2
+
+        # del level32_new_1
+        # del level32_new_2
+
+        level_4_prev = level_4_curr
+        level_4_curr = level4_new
+
+        level_8_prev = level_8_curr
+        level_8_curr = level8_new
+
+        level_16_prev = level_16_curr
+        level_16_curr = level16_new
+
+        level_32_prev = level_32_curr
+        level_32_curr = level32_new
+
+        for layer in range(4, self._num_layers - 1):
+
+            level4_new_1, level4_new_2 = self.cells[13] (level_4_prev,
+                                              None,
+                                              level_4_curr,
+                                              level_8_curr,
+                                              normalized_alphas)
+
+            level4_new = normalized_bottom_betas[layer][0] * level4_new_1 + normalized_bottom_betas[layer][1] * level4_new_2
+
+            # del level4_new_1
+            # del level4_new_2
+
+            level8_new_1, level8_new_2, level8_new_3 = self.cells[14] (level_8_prev,
+                                                                          level_4_curr,
+                                                                          level_8_curr,
+                                                                          level_16_curr,
+                                                                          normalized_alphas)
+
+            level8_new = normalized_betas8[layer - 1][0] * level8_new_1 + normalized_betas8[layer - 1][1] * level8_new_2 + normalized_betas8[layer - 1][2] * level8_new_3
+
+            # del level8_new_1
+            # del level8_new_2
+            # del level8_new_3
+
+            level16_new_1, level16_new_2, level16_new_3 = self.cells[15] (level_16_prev,
+                                                                             level_8_curr,
+                                                                             level_16_curr,
+                                                                             level_32_curr,
+                                                                             normalized_alphas)
+
+            level16_new = normalized_betas16[layer - 2][0] * level16_new_1 + normalized_betas16[layer - 2][1] * level16_new_2 + normalized_betas16[layer - 2][2] * level16_new_3
+
+            # del level16_new_1
+            # del level16_new_2
+            # del level16_new_3
+
+            level32_new_1, level32_new_2 = self.cells[16] (level_32_prev,
+                                                              level_16_curr,
+                                                              level_32_curr,
+                                                              None,
+                                                              normalized_alphas)
+
+            level32_new = normalized_top_betas[layer][0] * level32_new_1 + normalized_top_betas[layer][1] * level32_new_2
+
+            # del level32_new_1
+            # del level32_new_2
+
+            level_4_prev = level_4_curr
+            level_4_curr = level4_new
+
+            level_8_prev = level_8_curr
+            level_8_curr = level8_new
+
+            level_16_prev = level_16_curr
+            level_16_curr = level16_new
+
+            level_32_prev = level_32_curr
+            level_32_curr = level32_new
+
+        aspp_result_4 = self.aspp_4 (level_4_curr)
+        aspp_result_8 = self.aspp_8 (level_8_curr)
+        aspp_result_16 = self.aspp_16 (level_16_curr)
+        aspp_result_32 = self.aspp_32 (level_32_curr)
+
         upsample = nn.Upsample(size=x.size()[2:], mode='bilinear', align_corners=True)
         aspp_result_4 = upsample (aspp_result_4)
         aspp_result_8 = upsample (aspp_result_8)

--- a/auto_deeplab.py
+++ b/auto_deeplab.py
@@ -19,92 +19,124 @@ class AutoDeeplab (nn.Module) :
         self._filter_multiplier = filter_multiplier
         self._criterion = criterion
         self._initialize_alphas_betas ()
-        C_initial = 128
+        C_initial = self._filter_multiplier *  self._block_multiplier
+        half_C_initial = int(C_initial / 2)
+
         self.stem0 = nn.Sequential(
-            nn.Conv2d(3, 64, 3, stride=2, padding=1),
-            nn.BatchNorm2d(64),
+            nn.Conv2d(3, half_C_initial, 3, stride=2, padding=1),
+            nn.BatchNorm2d(half_C_initial),
             nn.ReLU ()
         )
         self.stem1 = nn.Sequential(
-            nn.Conv2d(64, 64, 3, padding=1),
-            nn.BatchNorm2d(64),
+            nn.Conv2d(half_C_initial, half_C_initial, 3, stride=1, padding=1),
+            nn.BatchNorm2d(half_C_initial),
             nn.ReLU ()
         )
         self.stem2 = nn.Sequential(
-            nn.Conv2d(64, C_initial, 3, stride=2, padding=1),
+            nn.Conv2d(half_C_initial, C_initial, 3, stride=2, padding=1),
             nn.BatchNorm2d(C_initial),
             nn.ReLU ()
         )
 
-        #C_prev_prev = 64
+
         intitial_fm = C_initial / self._block_multiplier
+        for i in range (self._num_layers) :
 
-        ### init the self.cells array
 
-        # layer == 0:
-
-        self.cells += [cell (self._step, self._block_multiplier, -1,
-                             None, intitial_fm, None, self._filter_multiplier)]
-        self.cells += [cell (self._step, self._block_multiplier, -1,
-                             intitial_fm, None, None, self._filter_multiplier * 2)]
-
-        # layer == 1:
-
-        self.cells += [cell (self._step, self._block_multiplier, intitial_fm,
-                             None, self._filter_multiplier, self._filter_multiplier * 2, self._filter_multiplier)]
-        self.cells += [cell (self._step, self._block_multiplier, -1,
-                             self._filter_multiplier, self._filter_multiplier * 2, None, self._filter_multiplier * 2)]
-        self.cells += [cell (self._step, self._block_multiplier, -1,
-                             self._filter_multiplier * 2, None, None, self._filter_multiplier * 4)]
-
-        # layer == 2:
-
-        self.cells += [cell (self._step, self._block_multiplier, self._filter_multiplier,
+            if i == 0 :
+                cell1 = cell (self._step, self._block_multiplier, -1,
+                              None, intitial_fm, None,
+                              self._filter_multiplier)
+                cell2 = cell (self._step, self._block_multiplier, -1,
+                              intitial_fm, None, None,
+                              self._filter_multiplier * 2)
+                self.cells += [cell1]
+                self.cells += [cell2]
+            elif i == 1 :
+                cell1 = cell (self._step, self._block_multiplier, intitial_fm,
                               None, self._filter_multiplier, self._filter_multiplier * 2,
-                              self._filter_multiplier)]
-        self.cells += [cell (self._step, self._block_multiplier, self._filter_multiplier * 2,
+                              self._filter_multiplier)
+
+                cell2 = cell (self._step, self._block_multiplier, -1,
+                              self._filter_multiplier, self._filter_multiplier * 2, None,
+                              self._filter_multiplier * 2)
+
+                cell3 = cell (self._step, self._block_multiplier, -1,
+                              self._filter_multiplier * 2, None, None,
+                              self._filter_multiplier * 4)
+
+                self.cells += [cell1]
+                self.cells += [cell2]
+                self.cells += [cell3]
+
+            elif i == 2 :
+                cell1 = cell (self._step, self._block_multiplier, self._filter_multiplier,
+                              None, self._filter_multiplier, self._filter_multiplier * 2,
+                              self._filter_multiplier)
+
+                cell2 = cell (self._step, self._block_multiplier, self._filter_multiplier * 2,
                               self._filter_multiplier, self._filter_multiplier * 2, self._filter_multiplier * 4,
-                              self._filter_multiplier * 2)]
-        self.cells += [cell (self._step, self._block_multiplier, -1,
+                              self._filter_multiplier * 2)
+
+                cell3 = cell (self._step, self._block_multiplier, -1,
                               self._filter_multiplier * 2, self._filter_multiplier * 4, None,
-                              self._filter_multiplier * 4)]
-        self.cells += [cell (self._step, self._block_multiplier, -1,
+                              self._filter_multiplier * 4)
+
+                cell4 = cell (self._step, self._block_multiplier, -1,
                               self._filter_multiplier * 4, None, None,
-                              self._filter_multiplier * 8)]
+                              self._filter_multiplier * 8)
 
-        # layer == 3:
+                self.cells += [cell1]
+                self.cells += [cell2]
+                self.cells += [cell3]
+                self.cells += [cell4]
 
-        self.cells += [cell (self._step, self._block_multiplier, self._filter_multiplier,
+
+
+            elif i == 3 :
+                cell1 = cell (self._step, self._block_multiplier, self._filter_multiplier,
                               None, self._filter_multiplier, self._filter_multiplier * 2,
-                              self._filter_multiplier)]
-        self.cells += [cell (self._step, self._block_multiplier, self._filter_multiplier * 2,
+                              self._filter_multiplier)
+
+                cell2 = cell (self._step, self._block_multiplier, self._filter_multiplier * 2,
                               self._filter_multiplier, self._filter_multiplier * 2, self._filter_multiplier * 4,
-                              self._filter_multiplier * 2)]
-        self.cells += [cell (self._step, self._block_multiplier, self._filter_multiplier * 4,
+                              self._filter_multiplier * 2)
+
+                cell3 = cell (self._step, self._block_multiplier, self._filter_multiplier * 4,
                               self._filter_multiplier * 2, self._filter_multiplier * 4, self._filter_multiplier * 8,
-                              self._filter_multiplier * 4)]
-        self.cells += [cell (self._step, self._block_multiplier, -1,
+                              self._filter_multiplier * 4)
+
+
+                cell4 = cell (self._step, self._block_multiplier, -1,
                               self._filter_multiplier * 4, self._filter_multiplier * 8, None,
-                              self._filter_multiplier * 8)]
+                              self._filter_multiplier * 8)
 
-        # layer > 3:
+                self.cells += [cell1]
+                self.cells += [cell2]
+                self.cells += [cell3]
+                self.cells += [cell4]
 
-        self.cells += [cell(self._step, self._block_multiplier, self._filter_multiplier,
-                            None, self._filter_multiplier, self._filter_multiplier * 2,
-                            self._filter_multiplier)]
-        self.cells += [cell(self._step, self._block_multiplier, self._filter_multiplier * 2,
-                            self._filter_multiplier, self._filter_multiplier * 2, self._filter_multiplier * 4,
-                            self._filter_multiplier * 2)]
-        self.cells += [cell(self._step, self._block_multiplier, self._filter_multiplier * 4,
-                            self._filter_multiplier * 2, self._filter_multiplier * 4, self._filter_multiplier * 8,
-                            self._filter_multiplier * 4)]
-        self.cells += [cell(self._step, self._block_multiplier, self._filter_multiplier * 8,
-                            self._filter_multiplier * 4, self._filter_multiplier * 8, None,
-                            self._filter_multiplier * 8)]
+            else :
+                cell1 = cell (self._step, self._block_multiplier, self._filter_multiplier,
+                                None, self._filter_multiplier, self._filter_multiplier * 2,
+                                self._filter_multiplier)
 
-        # for i in range (4, self._num_layers) :
-        # def __init__(self, steps, multiplier, C_prev_prev, C_initial, C, rate) : rate = 0 , 1, 2  reduce rate
+                cell2 = cell (self._step, self._block_multiplier, self._filter_multiplier * 2,
+                              self._filter_multiplier, self._filter_multiplier * 2, self._filter_multiplier * 4,
+                              self._filter_multiplier * 2)
 
+                cell3 = cell (self._step, self._block_multiplier, self._filter_multiplier * 4,
+                                self._filter_multiplier * 2, self._filter_multiplier * 4, self._filter_multiplier * 8,
+                                self._filter_multiplier * 4)
+
+                cell4 = cell (self._step, self._block_multiplier, self._filter_multiplier * 8,
+                                self._filter_multiplier * 4, self._filter_multiplier * 8, None,
+                                self._filter_multiplier * 8)
+
+                self.cells += [cell1]
+                self.cells += [cell2]
+                self.cells += [cell3]
+                self.cells += [cell4]
 
         self.aspp_4 = nn.Sequential (
             ASPP (self._block_multiplier * self._filter_multiplier, self._num_classes, 24, 24) #96 / 4 as in the paper
@@ -119,16 +151,20 @@ class AutoDeeplab (nn.Module) :
             ASPP (self._block_multiplier * self._filter_multiplier * 8, self._num_classes, 3, 3) #96 / 32
         )
 
+
+
     def forward (self, x) :
-        # self._init_level_arr (x)
-        cell = cell_level_search.Cell
-        C_initial = 128
-        intitial_fm = C_initial / self._block_multiplier
+        #TODO: GET RID OF THESE LISTS, we dont need to keep everything.
+        #TODO: Is this the reason for the memory issue ?
+        self.level_4 = []
+        self.level_8 = []
+        self.level_16 = []
+        self.level_32 = []
+        temp = self.stem0 (x)
+        temp = self.stem1 (temp)
+        self.level_4.append (self.stem2 (temp))
 
-        level_2_curr = self.stem1 (self.stem0 (x))
-        level_4_curr = self.stem2 (level_2_curr)
-
-        # del level_2_curr
+        count = 0
 
         if torch.cuda.device_count() > 1:
             img_device = torch.device('cuda', x.get_device())
@@ -143,236 +179,176 @@ class AutoDeeplab (nn.Module) :
             normalized_betas8 = F.softmax (self.betas8, dim = -1)
             normalized_betas16 = F.softmax(self.betas16, dim=-1)
             normalized_top_betas = F.softmax(self.top_betas, dim=-1)
-
-
-        # layer == 0 :
-
-        cell_curr = cell (self._step, self._block_multiplier, -1,
-                             None, intitial_fm, None, self._filter_multiplier)
-        level4_new, = self.cells[0] (None, None, level_4_curr, None, normalized_alphas)
-        level8_new, = self.cells[1] (None, level_4_curr, None, None, normalized_alphas)
-
-        level_4_prev = level_4_curr
-        level_4_curr = level4_new
-        level_8_curr = level8_new
-
-        # layer == 1 :
-
-        level4_new_1, level4_new_2 = self.cells[2] (level_4_prev,
-                                                        None,
-                                                        level_4_curr,
-                                                        level_8_curr,
-                                                        normalized_alphas)
-
-        level4_new = normalized_bottom_betas[1][0] * level4_new_1 + normalized_bottom_betas[1][1] * level4_new_2
-
-        # del level4_new_1
-        # del level4_new_2
-
-        level8_new_1, level8_new_2 = self.cells[3] (None,
-                                                        level_4_curr,
-                                                        level_8_curr,
-                                                        None,
-                                                        normalized_alphas)
-
-        level8_new = normalized_top_betas[1][0] * level8_new_1 + normalized_top_betas[1][1] * level8_new_2
-
-        # del level8_new_1
-        # del level8_new_2
-
-        level16_new, = self.cells[4] (None,
-                                          level_8_curr,
-                                          None,
-                                          None,
-                                          normalized_alphas)
-        # level16_new = level16_new
-
-        level_4_prev = level_4_curr
-        level_4_curr = level4_new
-
-        level_8_prev = level_8_curr
-        level_8_curr = level8_new
-
-        level_16_curr = level16_new
-
-        # layer == 2 :
-
-        level4_new_1, level4_new_2 = self.cells[5] (level_4_prev,
-                                                        None,
-                                                        level_4_curr,
-                                                        level_8_curr,
-                                                        normalized_alphas)
-
-        level4_new = normalized_bottom_betas[2][0] * level4_new_1 + normalized_bottom_betas[2][1] * level4_new_2
-
-        # del level4_new_1
-        # del level4_new_2
-
-        level8_new_1, level8_new_2, level8_new_3 = self.cells[6] (level_8_prev,
-                                                                      level_4_curr,
-                                                                      level_8_curr,
-                                                                      level_16_curr,
-                                                                      normalized_alphas)
-
-        level8_new = normalized_betas8[2 - 1][0] * level8_new_1 + normalized_betas8[2 - 1][1] * level8_new_2 + normalized_betas8[2 - 1][2] * level8_new_3
-
-        # del level8_new_1
-        # del level8_new_2
-        # del level8_new_3
-
-        level16_new_1, level16_new_2 = self.cells[7] (None,
-                                                          level_8_curr,
-                                                          level_16_curr,
-                                                          None,
-                                                          normalized_alphas)
-
-        level16_new = normalized_top_betas[2][0] * level16_new_1 + normalized_top_betas[2][1] * level16_new_2
-
-        # del level16_new_1
-        # del level16_new_2
-
-        level32_new, = self.cells[8] (None,
-                                          level_16_curr,
-                                          None,
-                                          None,
-                                          normalized_alphas)
-
-        level_4_prev = level_4_curr
-        level_4_curr = level4_new
-
-        level_8_prev = level_8_curr
-        level_8_curr = level8_new
-
-        level_16_prev = level_16_curr
-        level_16_curr = level16_new
-
-        level_32_curr = level32_new
-
-        # layer == 3 :
-
-        level4_new_1, level4_new_2 = self.cells[9] (level_4_prev,
-                                                        None,
-                                                        level_4_curr,
-                                                        level_8_curr,
-                                                        normalized_alphas)
-
-        level4_new = normalized_bottom_betas[3][0] * level4_new_1 + normalized_bottom_betas[3][1] * level4_new_2
-
-        # del level4_new_1
-        # del level4_new_2
-
-        level8_new_1, level8_new_2, level8_new_3 = self.cells[10] (level_8_prev,
-                                                                      level_4_curr,
-                                                                      level_8_curr,
-                                                                      level_16_curr,
-                                                                      normalized_alphas)
-
-        level8_new = normalized_betas8[3 - 1][0] * level8_new_1 + normalized_betas8[3 - 1][1] * level8_new_2 + normalized_betas8[3 - 1][2] * level8_new_3
-
-        # del level8_new_1
-        # del level8_new_2
-        # del level8_new_3
-
-        level16_new_1, level16_new_2, level16_new_3 = self.cells[11] (level_16_prev,
-                                                                         level_8_curr,
-                                                                         level_16_curr,
-                                                                         level_32_curr,
-                                                                         normalized_alphas)
-
-        level16_new = normalized_betas16[3 - 2][0] * level16_new_1 + normalized_betas16[3 - 2][1] * level16_new_2 + normalized_betas16[3 - 2][2] * level16_new_3
-
-        # del level16_new_1
-        # del level16_new_2
-        # del level16_new_3
-
-        level32_new_1, level32_new_2 = self.cells[12] (None,
-                                                          level_16_curr,
-                                                          level_32_curr,
-                                                          None,
-                                                          normalized_alphas)
-
-        level32_new = normalized_top_betas[3][0] * level32_new_1 + normalized_top_betas[3][1] * level32_new_2
-
-        # del level32_new_1
-        # del level32_new_2
-
-        level_4_prev = level_4_curr
-        level_4_curr = level4_new
-
-        level_8_prev = level_8_curr
-        level_8_curr = level8_new
-
-        level_16_prev = level_16_curr
-        level_16_curr = level16_new
-
-        level_32_prev = level_32_curr
-        level_32_curr = level32_new
-
-        for layer in range(4, self._num_layers - 1):
-
-            level4_new_1, level4_new_2 = self.cells[13] (level_4_prev,
-                                              None,
-                                              level_4_curr,
-                                              level_8_curr,
-                                              normalized_alphas)
-
-            level4_new = normalized_bottom_betas[layer][0] * level4_new_1 + normalized_bottom_betas[layer][1] * level4_new_2
-
-            # del level4_new_1
-            # del level4_new_2
-
-            level8_new_1, level8_new_2, level8_new_3 = self.cells[14] (level_8_prev,
-                                                                          level_4_curr,
-                                                                          level_8_curr,
-                                                                          level_16_curr,
-                                                                          normalized_alphas)
-
-            level8_new = normalized_betas8[layer - 1][0] * level8_new_1 + normalized_betas8[layer - 1][1] * level8_new_2 + normalized_betas8[layer - 1][2] * level8_new_3
-
-            # del level8_new_1
-            # del level8_new_2
-            # del level8_new_3
-
-            level16_new_1, level16_new_2, level16_new_3 = self.cells[15] (level_16_prev,
-                                                                             level_8_curr,
-                                                                             level_16_curr,
-                                                                             level_32_curr,
-                                                                             normalized_alphas)
-
-            level16_new = normalized_betas16[layer - 2][0] * level16_new_1 + normalized_betas16[layer - 2][1] * level16_new_2 + normalized_betas16[layer - 2][2] * level16_new_3
-
-            # del level16_new_1
-            # del level16_new_2
-            # del level16_new_3
-
-            level32_new_1, level32_new_2 = self.cells[16] (level_32_prev,
-                                                              level_16_curr,
-                                                              level_32_curr,
-                                                              None,
-                                                              normalized_alphas)
-
-            level32_new = normalized_top_betas[layer][0] * level32_new_1 + normalized_top_betas[layer][1] * level32_new_2
-
-            # del level32_new_1
-            # del level32_new_2
-
-            level_4_prev = level_4_curr
-            level_4_curr = level4_new
-
-            level_8_prev = level_8_curr
-            level_8_curr = level8_new
-
-            level_16_prev = level_16_curr
-            level_16_curr = level16_new
-
-            level_32_prev = level_32_curr
-            level_32_curr = level32_new
-
-        aspp_result_4 = self.aspp_4 (level_4_curr)
-        aspp_result_8 = self.aspp_8 (level_8_curr)
-        aspp_result_16 = self.aspp_16 (level_16_curr)
-        aspp_result_32 = self.aspp_32 (level_32_curr)
-
+        for layer in range (self._num_layers - 1) :
+
+            if layer == 0 :
+                level4_new, = self.cells[count] (None, None, self.level_4[-1], None, normalized_alphas)
+                count += 1
+                level8_new, = self.cells[count] (None, self.level_4[-1], None, None, normalized_alphas)
+                count += 1
+                self.level_4.append (level4_new)
+                self.level_8.append (level8_new)
+
+            elif layer == 1 :
+                level4_new_1, level4_new_2 = self.cells[count] (self.level_4[-2],
+                                                                None,
+                                                                self.level_4[-1],
+                                                                self.level_8[-1],
+                                                                normalized_alphas)
+                count += 1
+                level4_new = normalized_bottom_betas[layer][0] * level4_new_1 + normalized_bottom_betas[layer][1] * level4_new_2
+
+                level8_new_1, level8_new_2 = self.cells[count] (None,
+                                                                self.level_4[-1],
+                                                                self.level_8[-1],
+                                                                None,
+                                                                normalized_alphas)
+                count += 1
+                level8_new = normalized_top_betas[layer][0] * level8_new_1 + normalized_top_betas[layer][1] * level8_new_2
+
+                level16_new, = self.cells[count] (None,
+                                                  self.level_8[-1],
+                                                  None,
+                                                  None,
+                                                  normalized_alphas)
+                level16_new = level16_new
+                count += 1
+
+
+                self.level_4.append (level4_new)
+                self.level_8.append (level8_new)
+                self.level_16.append (level16_new)
+
+            elif layer == 2 :
+                level4_new_1, level4_new_2 = self.cells[count] (self.level_4[-2],
+                                                                None,
+                                                                self.level_4[-1],
+                                                                self.level_8[-1],
+                                                                normalized_alphas)
+                count += 1
+                level4_new = normalized_bottom_betas[layer][0] * level4_new_1 + normalized_bottom_betas[layer][1] * level4_new_2
+
+                level8_new_1, level8_new_2, level8_new_3 = self.cells[count] (self.level_8[-2],
+                                                                              self.level_4[-1],
+                                                                              self.level_8[-1],
+                                                                              self.level_16[-1],
+                                                                              normalized_alphas)
+                count += 1
+                level8_new = normalized_betas8[layer - 1][0] * level8_new_1 + normalized_betas8[layer - 1][1] * level8_new_2 + normalized_betas8[layer - 1][2] * level8_new_3
+
+                level16_new_1, level16_new_2 = self.cells[count] (None,
+                                                                  self.level_8[-1],
+                                                                  self.level_16[-1],
+                                                                  None,
+                                                                  normalized_alphas)
+                count += 1
+                level16_new = normalized_top_betas[layer][0] * level16_new_1 + normalized_top_betas[layer][1] * level16_new_2
+
+
+                level32_new, = self.cells[count] (None,
+                                                  self.level_16[-1],
+                                                  None,
+                                                  None,
+                                                  normalized_alphas)
+                level32_new = level32_new
+                count += 1
+
+                self.level_4.append (level4_new)
+                self.level_8.append (level8_new)
+                self.level_16.append (level16_new)
+                self.level_32.append (level32_new)
+
+            elif layer == 3 :
+                level4_new_1, level4_new_2 = self.cells[count] (self.level_4[-2],
+                                                                None,
+                                                                self.level_4[-1],
+                                                                self.level_8[-1],
+                                                                normalized_alphas)
+                count += 1
+                level4_new = normalized_bottom_betas[layer][0] * level4_new_1 + normalized_bottom_betas[layer][1] * level4_new_2
+
+                level8_new_1, level8_new_2, level8_new_3 = self.cells[count] (self.level_8[-2],
+                                                                              self.level_4[-1],
+                                                                              self.level_8[-1],
+                                                                              self.level_16[-1],
+                                                                              normalized_alphas)
+                count += 1
+                level8_new = normalized_betas8[layer - 1][0] * level8_new_1 + normalized_betas8[layer - 1][1] * level8_new_2 + normalized_betas8[layer - 1][2] * level8_new_3
+
+                level16_new_1, level16_new_2, level16_new_3 = self.cells[count] (self.level_16[-2],
+                                                                                 self.level_8[-1],
+                                                                                 self.level_16[-1],
+                                                                                 self.level_32[-1],
+                                                                                 normalized_alphas)
+                count += 1
+                level16_new = normalized_betas16[layer - 2][0] * level16_new_1 + normalized_betas16[layer - 2][1] * level16_new_2 + normalized_betas16[layer - 2][2] * level16_new_3
+
+
+                level32_new_1, level32_new_2 = self.cells[count] (None,
+                                                                  self.level_16[-1],
+                                                                  self.level_32[-1],
+                                                                  None,
+                                                                  normalized_alphas)
+                count += 1
+                level32_new = normalized_top_betas[layer][0] * level32_new_1 + normalized_top_betas[layer][1] * level32_new_2
+
+
+                self.level_4.append (level4_new)
+                self.level_8.append (level8_new)
+                self.level_16.append (level16_new)
+                self.level_32.append (level32_new)
+
+
+            else :
+                level4_new_1, level4_new_2 = self.cells[count] (self.level_4[-2],
+                                                                None,
+                                                                self.level_4[-1],
+                                                                self.level_8[-1],
+                                                                normalized_alphas)
+                count += 1
+                level4_new = normalized_bottom_betas[layer][0] * level4_new_1 + normalized_bottom_betas[layer][1] * level4_new_2
+
+                level8_new_1, level8_new_2, level8_new_3 = self.cells[count] (self.level_8[-2],
+                                                                              self.level_4[-1],
+                                                                              self.level_8[-1],
+                                                                              self.level_16[-1],
+                                                                              normalized_alphas)
+                count += 1
+
+                level8_new = normalized_betas8[layer - 1][0] * level8_new_1 + normalized_betas8[layer - 1][1] * level8_new_2 + normalized_betas8[layer - 1][2] * level8_new_3
+
+                level16_new_1, layer16_new_2, layer16_new_3 = self.cells[count] (self.level_16[-2],
+                                                                                 self.level_8[-1],
+                                                                                 self.level_16[-1],
+                                                                                 self.level_32[-1],
+                                                                                 normalized_alphas)
+                count += 1
+                level16_new = normalized_betas16[layer - 2][0] * level16_new_1 + normalized_betas16[layer - 2][1] * level16_new_2 + normalized_betas16[layer - 2][2] * level16_new_3
+
+
+                level32_new_1, level32_new_2 = self.cells[count] (self.level_32[-2],
+                                                                  self.level_16[-1],
+                                                                  self.level_32[-1],
+                                                                  None,
+                                                                  normalized_alphas)
+                count += 1
+                level32_new = normalized_top_betas[layer][0] * level32_new_1 + normalized_top_betas[layer][1] * level32_new_2
+
+
+                self.level_4.append (level4_new)
+                self.level_8.append (level8_new)
+                self.level_16.append (level16_new)
+                self.level_32.append (level32_new)
+
+            self.level_4 = self.level_4[-2:]
+            self.level_8 = self.level_8[-2:]
+            self.level_16 = self.level_16[-2:]
+            self.level_32 = self.level_32[-2:]
+
+        aspp_result_4 = self.aspp_4 (self.level_4[-1])
+        aspp_result_8 = self.aspp_8 (self.level_8[-1])
+        aspp_result_16 = self.aspp_16 (self.level_16[-1])
+        aspp_result_32 = self.aspp_32 (self.level_32[-1])
         upsample = nn.Upsample(size=x.size()[2:], mode='bilinear', align_corners=True)
         aspp_result_4 = upsample (aspp_result_4)
         aspp_result_8 = upsample (aspp_result_8)
@@ -388,17 +364,11 @@ class AutoDeeplab (nn.Module) :
     def _initialize_alphas_betas(self):
         k = sum(1 for i in range(self._step) for n in range(2+i))
         num_ops = len(PRIMITIVES)
-        alphas = (1e-3 * torch.randn(k, num_ops)).cuda().clone().detach().requires_grad_(True)
-        bottom_betas = (1e-3 * torch.randn(self._num_layers - 1, 2)).cuda().clone().detach().requires_grad_(True)
-        betas8 = (1e-3 * torch.randn(self._num_layers - 2, 3)).cuda().clone().detach().requires_grad_(True)
-        betas16 = (1e-3 * torch.randn(self._num_layers - 3, 3)).cuda().clone().detach().requires_grad_(True)
-        top_betas = (1e-3 * torch.randn(self._num_layers - 1, 2)).cuda().clone().detach().requires_grad_(True)
-
-        # alphas = torch.tensor (1e-3*torch.randn(k, num_ops).cuda(), requires_grad=True)
-        # bottom_betas = torch.tensor (1e-3 * torch.randn(self._num_layers - 1, 2).cuda(), requires_grad=True)
-        # betas8 = torch.tensor (1e-3 * torch.randn(self._num_layers - 2, 3).cuda(), requires_grad=True)
-        # betas16 = torch.tensor(1e-3 * torch.randn(self._num_layers - 3, 3).cuda(), requires_grad=True)
-        # top_betas = torch.tensor (1e-3 * torch.randn(self._num_layers - 1, 2).cuda(), requires_grad=True)
+        alphas = torch.tensor (1e-3*torch.randn(k, num_ops).cuda(), requires_grad=True)
+        bottom_betas = torch.tensor (1e-3 * torch.randn(self._num_layers - 1, 2).cuda(), requires_grad=True)
+        betas8 = torch.tensor (1e-3 * torch.randn(self._num_layers - 2, 3).cuda(), requires_grad=True)
+        betas16 = torch.tensor(1e-3 * torch.randn(self._num_layers - 3, 3).cuda(), requires_grad=True)
+        top_betas = torch.tensor (1e-3 * torch.randn(self._num_layers - 1, 2).cuda(), requires_grad=True)
 
         self._arch_parameters = [
             alphas,

--- a/auto_deeplab.py
+++ b/auto_deeplab.py
@@ -152,19 +152,14 @@ class AutoDeeplab (nn.Module) :
         )
 
 
-
     def forward (self, x) :
         #TODO: GET RID OF THESE LISTS, we dont need to keep everything.
         #TODO: Is this the reason for the memory issue ?
-        self.level_4 = []
-        self.level_8 = []
-        self.level_16 = []
-        self.level_32 = []
-        temp = self.stem0 (x)
-        temp = self.stem1 (temp)
-        self.level_4.append (self.stem2 (temp))
 
-        count = 0
+        level_2_curr = self.stem1 (self.stem0 (x))
+        level_4_curr = self.stem2 (level_2_curr)
+
+        # del level_2_curr
 
         if torch.cuda.device_count() > 1:
             img_device = torch.device('cuda', x.get_device())
@@ -179,196 +174,277 @@ class AutoDeeplab (nn.Module) :
             normalized_betas8 = F.softmax (self.betas8, dim = -1)
             normalized_betas16 = F.softmax(self.betas16, dim=-1)
             normalized_top_betas = F.softmax(self.top_betas, dim=-1)
-        for layer in range (self._num_layers - 1) :
+
+        count = 0
+
+        for layer in range(self._num_layers - 1):
 
             if layer == 0 :
-                level4_new, = self.cells[count] (None, None, self.level_4[-1], None, normalized_alphas)
+
+                level4_new, = self.cells[count](None, None, level_4_curr, None, normalized_alphas)
                 count += 1
-                level8_new, = self.cells[count] (None, self.level_4[-1], None, None, normalized_alphas)
+                level8_new, = self.cells[count](None, level_4_curr, None, None, normalized_alphas)
                 count += 1
-                self.level_4.append (level4_new)
-                self.level_8.append (level8_new)
+
+                level_4_prev = level_4_curr
+                level_4_curr = level4_new
+                level_8_curr = level8_new
 
             elif layer == 1 :
-                level4_new_1, level4_new_2 = self.cells[count] (self.level_4[-2],
-                                                                None,
-                                                                self.level_4[-1],
-                                                                self.level_8[-1],
-                                                                normalized_alphas)
+
+                level4_new_1, level4_new_2 = self.cells[count](level_4_prev,
+                                                           None,
+                                                           level_4_curr,
+                                                           level_8_curr,
+                                                           normalized_alphas)
                 count += 1
                 level4_new = normalized_bottom_betas[layer][0] * level4_new_1 + normalized_bottom_betas[layer][1] * level4_new_2
 
-                level8_new_1, level8_new_2 = self.cells[count] (None,
-                                                                self.level_4[-1],
-                                                                self.level_8[-1],
-                                                                None,
-                                                                normalized_alphas)
+                # del level4_new_1
+                # del level4_new_2
+
+                level8_new_1, level8_new_2 = self.cells[count](None,
+                                                           level_4_curr,
+                                                           level_8_curr,
+                                                           None,
+                                                           normalized_alphas)
                 count += 1
                 level8_new = normalized_top_betas[layer][0] * level8_new_1 + normalized_top_betas[layer][1] * level8_new_2
 
-                level16_new, = self.cells[count] (None,
-                                                  self.level_8[-1],
-                                                  None,
-                                                  None,
-                                                  normalized_alphas)
-                level16_new = level16_new
+                # del level8_new_1
+                # del level8_new_2
+
+                level16_new, = self.cells[count](None,
+                                             level_8_curr,
+                                             None,
+                                             None,
+                                             normalized_alphas)
                 count += 1
 
+                level_4_prev = level_4_curr
+                level_4_curr = level4_new
 
-                self.level_4.append (level4_new)
-                self.level_8.append (level8_new)
-                self.level_16.append (level16_new)
+                level_8_prev = level_8_curr
+                level_8_curr = level8_new
+
+                level_16_curr = level16_new
 
             elif layer == 2 :
-                level4_new_1, level4_new_2 = self.cells[count] (self.level_4[-2],
-                                                                None,
-                                                                self.level_4[-1],
-                                                                self.level_8[-1],
-                                                                normalized_alphas)
+
+                level4_new_1, level4_new_2 = self.cells[count](level_4_prev,
+                                                           None,
+                                                           level_4_curr,
+                                                           level_8_curr,
+                                                           normalized_alphas)
                 count += 1
                 level4_new = normalized_bottom_betas[layer][0] * level4_new_1 + normalized_bottom_betas[layer][1] * level4_new_2
 
-                level8_new_1, level8_new_2, level8_new_3 = self.cells[count] (self.level_8[-2],
-                                                                              self.level_4[-1],
-                                                                              self.level_8[-1],
-                                                                              self.level_16[-1],
-                                                                              normalized_alphas)
-                count += 1
-                level8_new = normalized_betas8[layer - 1][0] * level8_new_1 + normalized_betas8[layer - 1][1] * level8_new_2 + normalized_betas8[layer - 1][2] * level8_new_3
+                # del level4_new_1
+                # del level4_new_2
 
-                level16_new_1, level16_new_2 = self.cells[count] (None,
-                                                                  self.level_8[-1],
-                                                                  self.level_16[-1],
-                                                                  None,
-                                                                  normalized_alphas)
+                level8_new_1, level8_new_2, level8_new_3 = self.cells[count](level_8_prev,
+                                                                         level_4_curr,
+                                                                         level_8_curr,
+                                                                         level_16_curr,
+                                                                         normalized_alphas)
+                count += 1
+                level8_new = normalized_betas8[layer - 1][0] * level8_new_1 + normalized_betas8[layer - 1][1] * level8_new_2 + \
+                             normalized_betas8[layer - 1][2] * level8_new_3
+
+                # del level8_new_1
+                # del level8_new_2
+                # del level8_new_3
+
+                level16_new_1, level16_new_2 = self.cells[count](None,
+                                                             level_8_curr,
+                                                             level_16_curr,
+                                                             None,
+                                                             normalized_alphas)
                 count += 1
                 level16_new = normalized_top_betas[layer][0] * level16_new_1 + normalized_top_betas[layer][1] * level16_new_2
 
+                # del level16_new_1
+                # del level16_new_2
 
-                level32_new, = self.cells[count] (None,
-                                                  self.level_16[-1],
-                                                  None,
-                                                  None,
-                                                  normalized_alphas)
-                level32_new = level32_new
+                level32_new, = self.cells[count](None,
+                                             level_16_curr,
+                                             None,
+                                             None,
+                                             normalized_alphas)
+
                 count += 1
+                level_4_prev = level_4_curr
+                level_4_curr = level4_new
 
-                self.level_4.append (level4_new)
-                self.level_8.append (level8_new)
-                self.level_16.append (level16_new)
-                self.level_32.append (level32_new)
+                level_8_prev = level_8_curr
+                level_8_curr = level8_new
+
+                level_16_prev = level_16_curr
+                level_16_curr = level16_new
+
+                level_32_curr = level32_new
 
             elif layer == 3 :
-                level4_new_1, level4_new_2 = self.cells[count] (self.level_4[-2],
-                                                                None,
-                                                                self.level_4[-1],
-                                                                self.level_8[-1],
-                                                                normalized_alphas)
+
+                level4_new_1, level4_new_2 = self.cells[count](level_4_prev,
+                                                           None,
+                                                           level_4_curr,
+                                                           level_8_curr,
+                                                           normalized_alphas)
                 count += 1
                 level4_new = normalized_bottom_betas[layer][0] * level4_new_1 + normalized_bottom_betas[layer][1] * level4_new_2
 
-                level8_new_1, level8_new_2, level8_new_3 = self.cells[count] (self.level_8[-2],
-                                                                              self.level_4[-1],
-                                                                              self.level_8[-1],
-                                                                              self.level_16[-1],
+                # del level4_new_1
+                # del level4_new_2
+
+                level8_new_1, level8_new_2, level8_new_3 = self.cells[count](level_8_prev,
+                                                                          level_4_curr,
+                                                                          level_8_curr,
+                                                                          level_16_curr,
+                                                                          normalized_alphas)
+                count += 1
+                level8_new = normalized_betas8[layer - 1][0] * level8_new_1 + normalized_betas8[layer - 1][1] * level8_new_2 + \
+                             normalized_betas8[layer - 1][2] * level8_new_3
+
+                # del level8_new_1
+                # del level8_new_2
+                # del level8_new_3
+
+                level16_new_1, level16_new_2, level16_new_3 = self.cells[count](level_16_prev,
+                                                                             level_8_curr,
+                                                                             level_16_curr,
+                                                                             level_32_curr,
+                                                                             normalized_alphas)
+                count += 1
+                level16_new = normalized_betas16[layer - 2][0] * level16_new_1 + normalized_betas16[layer - 2][1] * level16_new_2 + \
+                              normalized_betas16[layer - 2][2] * level16_new_3
+
+                # del level16_new_1
+                # del level16_new_2
+                # del level16_new_3
+
+                level32_new_1, level32_new_2 = self.cells[count](None,
+                                                              level_16_curr,
+                                                              level_32_curr,
+                                                              None,
+                                                              normalized_alphas)
+                count += 1
+                level32_new = normalized_top_betas[layer][0] * level32_new_1 + normalized_top_betas[layer][1] * level32_new_2
+
+                # del level32_new_1
+                # del level32_new_2
+
+                level_4_prev = level_4_curr
+                level_4_curr = level4_new
+
+                level_8_prev = level_8_curr
+                level_8_curr = level8_new
+
+                level_16_prev = level_16_curr
+                level_16_curr = level16_new
+
+                level_32_prev = level_32_curr
+                level_32_curr = level32_new
+
+
+            else:
+                level4_new_1, level4_new_2 = self.cells[count] (level_4_prev,
+                                                  None,
+                                                  level_4_curr,
+                                                  level_8_curr,
+                                                  normalized_alphas)
+                count += 1
+                level4_new = normalized_bottom_betas[layer][0] * level4_new_1 + normalized_bottom_betas[layer][1] * level4_new_2
+
+                # del level4_new_1
+                # del level4_new_2
+
+                level8_new_1, level8_new_2, level8_new_3 = self.cells[count] (level_8_prev,
+                                                                              level_4_curr,
+                                                                              level_8_curr,
+                                                                              level_16_curr,
                                                                               normalized_alphas)
                 count += 1
                 level8_new = normalized_betas8[layer - 1][0] * level8_new_1 + normalized_betas8[layer - 1][1] * level8_new_2 + normalized_betas8[layer - 1][2] * level8_new_3
 
-                level16_new_1, level16_new_2, level16_new_3 = self.cells[count] (self.level_16[-2],
-                                                                                 self.level_8[-1],
-                                                                                 self.level_16[-1],
-                                                                                 self.level_32[-1],
+                # del level8_new_1
+                # del level8_new_2
+                # del level8_new_3
+
+                level16_new_1, level16_new_2, level16_new_3 = self.cells[count] (level_16_prev,
+                                                                                 level_8_curr,
+                                                                                 level_16_curr,
+                                                                                 level_32_curr,
                                                                                  normalized_alphas)
                 count += 1
                 level16_new = normalized_betas16[layer - 2][0] * level16_new_1 + normalized_betas16[layer - 2][1] * level16_new_2 + normalized_betas16[layer - 2][2] * level16_new_3
 
+                # del level16_new_1
+                # del level16_new_2
+                # del level16_new_3
 
-                level32_new_1, level32_new_2 = self.cells[count] (None,
-                                                                  self.level_16[-1],
-                                                                  self.level_32[-1],
+                level32_new_1, level32_new_2 = self.cells[count] (level_32_prev,
+                                                                  level_16_curr,
+                                                                  level_32_curr,
                                                                   None,
                                                                   normalized_alphas)
                 count += 1
                 level32_new = normalized_top_betas[layer][0] * level32_new_1 + normalized_top_betas[layer][1] * level32_new_2
 
+                # del level32_new_1
+                # del level32_new_2
 
-                self.level_4.append (level4_new)
-                self.level_8.append (level8_new)
-                self.level_16.append (level16_new)
-                self.level_32.append (level32_new)
+                level_4_prev = level_4_curr
+                level_4_curr = level4_new
 
+                level_8_prev = level_8_curr
+                level_8_curr = level8_new
 
-            else :
-                level4_new_1, level4_new_2 = self.cells[count] (self.level_4[-2],
-                                                                None,
-                                                                self.level_4[-1],
-                                                                self.level_8[-1],
-                                                                normalized_alphas)
-                count += 1
-                level4_new = normalized_bottom_betas[layer][0] * level4_new_1 + normalized_bottom_betas[layer][1] * level4_new_2
+                level_16_prev = level_16_curr
+                level_16_curr = level16_new
 
-                level8_new_1, level8_new_2, level8_new_3 = self.cells[count] (self.level_8[-2],
-                                                                              self.level_4[-1],
-                                                                              self.level_8[-1],
-                                                                              self.level_16[-1],
-                                                                              normalized_alphas)
-                count += 1
+                level_32_prev = level_32_curr
+                level_32_curr = level32_new
 
-                level8_new = normalized_betas8[layer - 1][0] * level8_new_1 + normalized_betas8[layer - 1][1] * level8_new_2 + normalized_betas8[layer - 1][2] * level8_new_3
+        # del level_4_prev
+        # del level_8_prev
+        # del level_16_prev
+        # del level_32_prev
 
-                level16_new_1, layer16_new_2, layer16_new_3 = self.cells[count] (self.level_16[-2],
-                                                                                 self.level_8[-1],
-                                                                                 self.level_16[-1],
-                                                                                 self.level_32[-1],
-                                                                                 normalized_alphas)
-                count += 1
-                level16_new = normalized_betas16[layer - 2][0] * level16_new_1 + normalized_betas16[layer - 2][1] * level16_new_2 + normalized_betas16[layer - 2][2] * level16_new_3
+        aspp_result_4 = self.aspp_4(level_4_curr)
+        aspp_result_8 = self.aspp_8(level_8_curr)
+        aspp_result_16 = self.aspp_16(level_16_curr)
+        aspp_result_32 = self.aspp_32(level_32_curr)
 
+        # del level_4_curr
+        # del level_8_curr
+        # del level_16_curr
+        # del level_32_curr
 
-                level32_new_1, level32_new_2 = self.cells[count] (self.level_32[-2],
-                                                                  self.level_16[-1],
-                                                                  self.level_32[-1],
-                                                                  None,
-                                                                  normalized_alphas)
-                count += 1
-                level32_new = normalized_top_betas[layer][0] * level32_new_1 + normalized_top_betas[layer][1] * level32_new_2
-
-
-                self.level_4.append (level4_new)
-                self.level_8.append (level8_new)
-                self.level_16.append (level16_new)
-                self.level_32.append (level32_new)
-
-            self.level_4 = self.level_4[-2:]
-            self.level_8 = self.level_8[-2:]
-            self.level_16 = self.level_16[-2:]
-            self.level_32 = self.level_32[-2:]
-
-        aspp_result_4 = self.aspp_4 (self.level_4[-1])
-        aspp_result_8 = self.aspp_8 (self.level_8[-1])
-        aspp_result_16 = self.aspp_16 (self.level_16[-1])
-        aspp_result_32 = self.aspp_32 (self.level_32[-1])
         upsample = nn.Upsample(size=x.size()[2:], mode='bilinear', align_corners=True)
         aspp_result_4 = upsample (aspp_result_4)
         aspp_result_8 = upsample (aspp_result_8)
         aspp_result_16 = upsample (aspp_result_16)
         aspp_result_32 = upsample (aspp_result_32)
 
-
         sum_feature_map = aspp_result_4 + aspp_result_8 + aspp_result_16 + aspp_result_32
-
 
         return sum_feature_map
 
     def _initialize_alphas_betas(self):
         k = sum(1 for i in range(self._step) for n in range(2+i))
         num_ops = len(PRIMITIVES)
-        alphas = torch.tensor (1e-3*torch.randn(k, num_ops).cuda(), requires_grad=True)
-        bottom_betas = torch.tensor (1e-3 * torch.randn(self._num_layers - 1, 2).cuda(), requires_grad=True)
-        betas8 = torch.tensor (1e-3 * torch.randn(self._num_layers - 2, 3).cuda(), requires_grad=True)
-        betas16 = torch.tensor(1e-3 * torch.randn(self._num_layers - 3, 3).cuda(), requires_grad=True)
-        top_betas = torch.tensor (1e-3 * torch.randn(self._num_layers - 1, 2).cuda(), requires_grad=True)
+        alphas = (1e-3 * torch.randn(k, num_ops)).cuda().clone().detach().requires_grad_(True)
+        bottom_betas = (1e-3 * torch.randn(self._num_layers - 1, 2)).cuda().clone().detach().requires_grad_(True)
+        betas8 = (1e-3 * torch.randn(self._num_layers - 2, 3)).cuda().clone().detach().requires_grad_(True)
+        betas16 = (1e-3 * torch.randn(self._num_layers - 3, 3)).cuda().clone().detach().requires_grad_(True)
+        top_betas = (1e-3 * torch.randn(self._num_layers - 1, 2)).cuda().clone().detach().requires_grad_(True)
+
+        # alphas = torch.tensor (1e-3*torch.randn(k, num_ops).cuda(), requires_grad=True)
+        # bottom_betas = torch.tensor (1e-3 * torch.randn(self._num_layers - 1, 2).cuda(), requires_grad=True)
+        # betas8 = torch.tensor (1e-3 * torch.randn(self._num_layers - 2, 3).cuda(), requires_grad=True)
+        # betas16 = torch.tensor(1e-3 * torch.randn(self._num_layers - 3, 3).cuda(), requires_grad=True)
+        # top_betas = torch.tensor (1e-3 * torch.randn(self._num_layers - 1, 2).cuda(), requires_grad=True)
 
         self._arch_parameters = [
             alphas,

--- a/train_autodeeplab.py
+++ b/train_autodeeplab.py
@@ -264,7 +264,7 @@ class Trainer(object):
         if new_pred > self.best_pred:
             is_best = True
             self.best_pred = new_pred
-            if len(self.args.gpu_ids) >1:
+            if torch.cuda.device_count() > 1:
                 state_dict = self.model.module.state_dict()
             else:
                 state_dict = self.model.state_dict()

--- a/train_autodeeplab.py
+++ b/train_autodeeplab.py
@@ -23,18 +23,13 @@ try:
 except ModuleNotFoundError:
     APEX_AVAILABLE = False
 
+
 print('working with pytorch version {}'.format(torch.__version__))
 print('with cuda version {}'.format(torch.version.cuda))
 print('cudnn enabled: {}'.format(torch.backends.cudnn.enabled))
 print('cudnn version: {}'.format(torch.backends.cudnn.version()))
 
-
 class Trainer(object):
-
-    def fix_bn(self,m):
-        classname = m.__class__.__name__
-        if classname.find('BatchNorm') != -1:
-            m.eval().half()
 
     def __init__(self, args):
         self.args = args
@@ -46,6 +41,7 @@ class Trainer(object):
         self.summary = TensorboardSummary(self.saver.experiment_dir)
         self.writer = self.summary.create_summary()
         self.use_amp = True if APEX_AVAILABLE else False
+        self.opt_level = args.opt_level
 
         kwargs = {'num_workers': args.workers, 'pin_memory': True}
         self.train_loaderA, self.train_loaderB, self.val_loader, self.test_loader, self.nclass = make_data_loader(args, **kwargs)
@@ -71,28 +67,18 @@ class Trainer(object):
                 weight_decay=args.weight_decay
             )
 
+
         self.model, self.optimizer = model, optimizer
+
+        self.architect_optimizer = torch.optim.Adam(self.model.arch_parameters(),
+                                                    lr=args.arch_lr, betas=(0.9, 0.999),
+                                                    weight_decay=args.arch_weight_decay)
+
         # Define Evaluator
         self.evaluator = Evaluator(self.nclass)
         # Define lr scheduler
         self.scheduler = LR_Scheduler(args.lr_scheduler, args.lr,
                                       args.epochs, len(self.train_loaderA), min_lr=args.min_lr)
-
-
-        self.architect_optimizer = torch.optim.Adam(self.model.arch_parameters(),
-                                                  lr=args.arch_lr, betas=(0.9, 0.999),
-                                                  weight_decay=args.arch_weight_decay)
-
-
-        # for module in self.model.modules():
-        #     if isinstance(module, torch.nn.modules.batchnorm._BatchNorm):
-        #         # Hack to fix BN fprop without affine transformation
-        #         if module.weight is None:
-        #             module.weight = torch.nn.Parameter(torch.ones(module.running_var.shape, dtype=module.running_var.dtype,
-        #                                                     device=module.running_var.device), requires_grad=False)
-        #         if module.bias is None:
-        #             module.bias = torch.nn.Parameter(torch.zeros(module.running_var.shape, dtype=module.running_var.dtype,
-        #                                                    device=module.running_var.device), requires_grad=False)
 
         # Using cuda
         if args.cuda:
@@ -101,26 +87,37 @@ class Trainer(object):
 
         # mixed precision
         if self.use_amp and args.cuda:
+            keep_batchnorm_fp32 = True if (self.opt_level == 'O2' or self.opt_level == 'O3') else None
+
+            # fix for current pytorch version with opt_level 'O1'
+            if self.opt_level == 'O1' and torch.__version__ < '1.3':
+                for module in self.model.modules():
+                    if isinstance(module, torch.nn.modules.batchnorm._BatchNorm):
+                        # Hack to fix BN fprop without affine transformation
+                        if module.weight is None:
+                            module.weight = torch.nn.Parameter(
+                                torch.ones(module.running_var.shape, dtype=module.running_var.dtype,
+                                           device=module.running_var.device), requires_grad=False)
+                        if module.bias is None:
+                            module.bias = torch.nn.Parameter(
+                                torch.zeros(module.running_var.shape, dtype=module.running_var.dtype,
+                                            device=module.running_var.device), requires_grad=False)
+
+            print(keep_batchnorm_fp32)
             self.model, [self.optimizer, self.architect_optimizer] = amp.initialize(
-                self.model, [self.optimizer, self.architect_optimizer], opt_level="O2",
-                keep_batchnorm_fp32=True, loss_scale="dynamic")
+                self.model, [self.optimizer, self.architect_optimizer], opt_level=self.opt_level,
+                keep_batchnorm_fp32=keep_batchnorm_fp32, loss_scale="dynamic")
 
             print('cuda finished')
-
-        # self.optimizer = FP16_Optimizer(self.optimizer,dynamic_loss_scale=True)
-
 
 
         # Using data parallel
         if args.cuda and len(self.args.gpu_ids) >1:
+            if self.opt_level == 'O2' or self.opt_level == 'O3':
+                print('currently cannot run with nn.DataParallel and optimization level', self.opt_level)
             self.model = torch.nn.DataParallel(self.model, device_ids=self.args.gpu_ids)
             patch_replication_callback(self.model)
             print('training on multiple-GPUs')
-            # self.model = apex.parallel.DistributedDataParallel(self.model)
-
-
-
-
 
         #checkpoint = torch.load(args.resume)
         #print('about to load state_dict')
@@ -166,7 +163,6 @@ class Trainer(object):
     def training(self, epoch):
         train_loss = 0.0
         self.model.train()
-        # self.model.apply(self.fix_bn)
         tbar = tqdm(self.train_loaderA)
         num_img_tr = len(self.train_loaderA)
         for i, sample in enumerate(tbar):
@@ -268,7 +264,7 @@ class Trainer(object):
         if new_pred > self.best_pred:
             is_best = True
             self.best_pred = new_pred
-            if torch.cuda.device_count() > 1:
+            if len(self.args.gpu_ids) >1:
                 state_dict = self.model.module.state_dict()
             else:
                 state_dict = self.model.state_dict()
@@ -284,6 +280,9 @@ def main():
     parser.add_argument('--backbone', type=str, default='resnet',
                         choices=['resnet', 'xception', 'drn', 'mobilenet'],
                         help='backbone name (default: resnet)')
+    parser.add_argument('--opt_level', type=str, default='O1',
+                        choices=['O0', 'O1', 'O2', 'O3'],
+                        help='opt level for half percision training (default: 01)')
     parser.add_argument('--out-stride', type=int, default=16,
                         help='network output stride (default: 8)')
     parser.add_argument('--dataset', type=str, default='kd',

--- a/train_autodeeplab.py
+++ b/train_autodeeplab.py
@@ -289,7 +289,9 @@ def main():
     parser.add_argument('--dataset', type=str, default='kd',
                         choices=['pascal', 'coco', 'cityscapes', 'kd'],
                         help='dataset name (default: pascal)')
-
+    parser.add_argument('--autodeeplab', type=str, default='search',
+                        choices=['search', 'train'],
+                        help='dataset name (default: pascal)')
     parser.add_argument('--use-sbd', action='store_true', default=False,
                         help='whether to use SBD dataset (default: True)')
     parser.add_argument('--load-parallel', type=int, default=0)


### PR DESCRIPTION
Hi,
in the forward() function we always use only the current and previous values of intermediate layers so there is no need to save all intermediate layers in a list. i replaced the lists with two local variables for the current and previous representations.

there was also a small typo bug with variables names, it is fixed now.

the memory reduction is not as drastic as i'd hoped, around ~1GB in my setting.