### PR TITLE
Fix new_model.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,5 @@ modeling/__pycache__/__init__.cpython-37.pyc
 modeling/__pycache__/aspp.cpython-37.pyc
 __pycache__/new_model.cpython-37.pyc
 __pycache__/cell_level_search.cpython-37.pyc
-test.py
 __pycache__/auto_deeplab.cpython-37.pyc
 __pycache__/decoding_formulas.cpython-37.pyc

--- a/test.py
+++ b/test.py
@@ -1,0 +1,228 @@
+import torch.nn as nn
+# from modeling.backbone.resnet import ResNet101
+# from lib.config_utils.basic_args import obtain_default_train_args
+import argparse
+from modeling.deeplab import DeepLab
+from auto_deeplab import AutoDeeplab
+from thop import profile
+from torchsummary import summary
+import warnings
+
+warnings.filterwarnings('ignore')
+
+
+def total_params(model, log=True):
+    params = sum(p.numel() / 1000.0 for p in model.parameters())
+    if log:
+        print(">>> total params: {:.2f}K".format(params))
+    return params
+
+
+def each_param(model):
+    for p in model.parameters():
+        print(">>> {:.5f}K".format(p.numel()))
+
+
+def obtain_default_search_args():
+    parser = argparse.ArgumentParser(
+        description="PyTorch DeeplabV3Plus Training")
+    parser.add_argument('--backbone', type=str, default='resnet',
+                        choices=['resnet', 'xception', 'drn', 'mobilenet'],
+                        help='backbone name (default: resnet)')
+    parser.add_argument('--out-stride', type=int, default=16,
+                        help='network output stride (default: 8)')
+    parser.add_argument('--dataset', type=str, default='cityscapes',
+                        choices=['pascal', 'coco', 'cityscapes', 'kd'],
+                        help='dataset name (default: pascal)')
+    parser.add_argument('--autodeeplab', type=str, default='search',
+                        choices=['search', 'train'])
+    parser.add_argument('--use-sbd', action='store_true', default=False,
+                        help='whether to use SBD dataset (default: True)')
+    parser.add_argument('--load-parallel', type=int, default=0)
+    parser.add_argument('--clean-module', type=int, default=0)
+    parser.add_argument('--workers', type=int, default=0,
+                        metavar='N', help='dataloader threads')
+    parser.add_argument('--base_size', type=int, default=320,
+                        help='base image size')
+    parser.add_argument('--crop_size', type=int, default=320,
+                        help='crop image size')
+    parser.add_argument('--resize', type=int, default=512,
+                        help='resize image size')
+    parser.add_argument('--sync-bn', type=bool, default=None,
+                        help='whether to use sync bn (default: auto)')
+    parser.add_argument('--freeze-bn', type=bool, default=False,
+                        help='whether to freeze bn parameters (default: False)')
+    parser.add_argument('--loss-type', type=str, default='ce',
+                        choices=['ce', 'focal'],
+                        help='loss func type (default: ce)')
+    # training hyper params
+    parser.add_argument('--epochs', type=int, default=None, metavar='N',
+                        help='number of epochs to train (default: auto)')
+    parser.add_argument('--start_epoch', type=int, default=0,
+                        metavar='N', help='start epochs (default:0)')
+    parser.add_argument('--filter_multiplier', type=int, default=8)
+    parser.add_argument('--block_multiplier', type=int, default=5)
+    parser.add_argument('--step', type=int, default=5)
+    parser.add_argument('--alpha_epoch', type=int, default=20,
+                        metavar='N', help='epoch to start training alphas')
+    parser.add_argument('--batch-size', type=int, default=2,
+                        metavar='N', help='input batch size for \
+                                training (default: auto)')
+    parser.add_argument('--test-batch-size', type=int, default=None,
+                        metavar='N', help='input batch size for \
+                                testing (default: auto)')
+    parser.add_argument('--use_balanced_weights', action='store_true', default=False,
+                        help='whether to use balanced weights (default: False)')
+    # optimizer params
+    parser.add_argument('--lr', type=float, default=0.025, metavar='LR',
+                        help='learning rate (default: auto)')
+    parser.add_argument('--min_lr', type=float, default=0.001)
+    parser.add_argument('--arch-lr', type=float, default=3e-3, metavar='LR',
+                        help='learning rate for alpha and beta in architect searching process')
+
+    parser.add_argument('--lr-scheduler', type=str, default='cos',
+                        choices=['poly', 'step', 'cos'],
+                        help='lr scheduler mode')
+    parser.add_argument('--momentum', type=float, default=0.9,
+                        metavar='M', help='momentum (default: 0.9)')
+    parser.add_argument('--weight-decay', type=float, default=3e-4,
+                        metavar='M', help='w-decay (default: 5e-4)')
+    parser.add_argument('--arch-weight-decay', type=float, default=1e-3,
+                        metavar='M', help='w-decay (default: 5e-4)')
+
+    parser.add_argument('--nesterov', action='store_true', default=False,
+                        help='whether use nesterov (default: False)')
+    # cuda, seed and logging
+    parser.add_argument('--no-cuda', action='store_true',
+                        default=False, help='disables CUDA training')
+    parser.add_argument('--gpu-ids', type=str, default='0',
+                        help='use which gpu to train, must be a \
+                        comma-separated list of integers only (default=0)')
+    parser.add_argument('--seed', type=int, default=1, metavar='S',
+                        help='random seed (default: 1)')
+    # checking point
+    parser.add_argument('--resume', type=str, default=None,
+                        help='put the path to resuming file if needed')
+    parser.add_argument('--checkname', type=str, default=None,
+                        help='set the checkpoint name')
+    # finetuning pre-trained models
+    parser.add_argument('--ft', action='store_true', default=False,
+                        help='finetuning on a different dataset')
+    # evaluation option
+    parser.add_argument('--eval-interval', type=int, default=1,
+                        help='evaluuation interval (default: 1)')
+    parser.add_argument('--no-val', action='store_true', default=False,
+                        help='skip validation during training')
+    return parser.parse_args()
+
+
+def obtain_default_train_args():
+    parser = argparse.ArgumentParser(
+        description="PyTorch DeeplabV3Plus Training")
+    parser.add_argument('--backbone', type=str, default='resnet',
+                        choices=['resnet', 'xception', 'drn', 'mobilenet'],
+                        help='backbone name (default: resnet)')
+    parser.add_argument('--out-stride', type=int, default=16,
+                        help='network output stride (default: 8)')
+    parser.add_argument('--dataset', type=str, default='pascal',
+                        choices=['pascal', 'coco', 'cityscapes'],
+                        help='dataset name (default: pascal)')
+    parser.add_argument('--use-sbd', action='store_true', default=True,
+                        help='whether to use SBD dataset (default: True)')
+    parser.add_argument('--workers', type=int, default=4,
+                        metavar='N', help='dataloader threads')
+    parser.add_argument('--base-size', type=int, default=513,
+                        help='base image size')
+    parser.add_argument('--crop-size', type=int, default=513,
+                        help='crop image size')
+    parser.add_argument('--sync-bn', type=bool, default=None,
+                        help='whether to use sync bn (default: auto)')
+    parser.add_argument('--freeze-bn', type=bool, default=False,
+                        help='whether to freeze bn parameters (default: False)')
+    parser.add_argument('--loss-type', type=str, default='ce',
+                        choices=['ce', 'focal'],
+                        help='loss func type (default: ce)')
+    # training hyper params
+    parser.add_argument('--epochs', type=int, default=None, metavar='N',
+                        help='number of epochs to train (default: auto)')
+    parser.add_argument('--start_epoch', type=int, default=0,
+                        metavar='N', help='start epochs (default:0)')
+    parser.add_argument('--batch-size', type=int, default=None,
+                        metavar='N', help='input batch size for \
+                                training (default: auto)')
+    parser.add_argument('--test-batch-size', type=int, default=None,
+                        metavar='N', help='input batch size for \
+                                testing (default: auto)')
+    parser.add_argument('--use-balanced-weights', action='store_true', default=False,
+                        help='whether to use balanced weights (default: False)')
+    # optimizer params
+    parser.add_argument('--lr', type=float, default=None, metavar='LR',
+                        help='learning rate (default: auto)')
+    parser.add_argument('--lr-scheduler', type=str, default='poly',
+                        choices=['poly', 'step', 'cos'],
+                        help='lr scheduler mode: (default: poly)')
+    parser.add_argument('--momentum', type=float, default=0.9,
+                        metavar='M', help='momentum (default: 0.9)')
+    parser.add_argument('--weight-decay', type=float, default=5e-4,
+                        metavar='M', help='w-decay (default: 5e-4)')
+    parser.add_argument('--nesterov', action='store_true', default=False,
+                        help='whether use nesterov (default: False)')
+    # cuda, seed and logging
+    parser.add_argument('--no-cuda', action='store_true',
+                        default=False, help='disables CUDA training')
+    parser.add_argument('--gpu-ids', type=str, default='0',
+                        help='use which gpu to train, must be a \
+                        comma-separated list of integers only (default=0)')
+    parser.add_argument('--seed', type=int, default=1, metavar='S',
+                        help='random seed (default: 1)')
+    # checking point
+    parser.add_argument('--resume', type=str, default=None,
+                        help='put the path to resuming file if needed')
+    parser.add_argument('--checkname', type=str, default=None,
+                        help='set the checkpoint name')
+    # finetuning pre-trained models
+    parser.add_argument('--ft', action='store_true', default=False,
+                        help='finetuning on a different dataset')
+    # evaluation option
+    parser.add_argument('--eval-interval', type=int, default=1,
+                        help='evaluation interval (default: 1)')
+    parser.add_argument('--no-val', action='store_true', default=False,
+                        help='skip validation during training')
+    parser.add_argument('--filter_multiplier', type=int,
+                        default=32, help='F in paper')
+    parser.add_argument('--steps', type=int, default=5, help='B in paper')
+    parser.add_argument('--down_sample_level', type=int,
+                        default=8, help='s in paper')
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    import torch
+    # model = ResNet101(BatchNorm=nn.BatchNorm2d,
+    #                   pretrained=True, output_stride=8)
+    input = torch.rand(2, 3, 128, 128).cuda()
+    # output, low_level_feat = model(input)
+    # print(output.size())
+    # print(low_level_feat.size())
+    args = obtain_default_train_args()
+    # model = DeepLab(num_classes=19,
+    #                 backbone='autodeeplab',
+    #                 output_stride=8,
+    #                 sync_bn=False,
+    #                 freeze_bn=False, args=args, separate=False)
+    args = obtain_default_search_args()
+    criterion = torch.nn.CrossEntropyLoss(ignore_index=255)
+    model = AutoDeeplab(num_classes=19, num_layers=12, criterion=criterion, filter_multiplier=args.filter_multiplier,
+                        block_multiplier=args.block_multiplier, step=args.step).cuda()
+    
+
+    output = model(input)
+    print(output)
+    # model.backbone(input)
+    # total_params(model)
+    # print(model.backbone.cells[1])
+    # params, flops = profile(model, inputs=(input,))
+    # print(params)
+    # print(flops)
+
+    # summary(model.backbone.cuda(), input_size=(3, 513, 513))


### PR DESCRIPTION
Fix the main difference between our code and hnasnet.py

1. the feature from previous and previous-previous cell are combined the same way as the hnasnet

2. in re-train model, all cells has prev-prev cell

3. use dilate conv instead of dilate separate conv

4. use xception-71 istead of sception-65 (it is the author said)

5. adapted the channel in decoder.py and aspp.py in deeplab v3+ code

6. fix for odd size just like (4*output_stride + 1)

7. test all the re-trained size of model, now the params match the Table2 in autodeeplab paper exactly, but the flops is different. Two reasons: the tensorflow has been optimized in later version, resulting in the lower flops, and pytorch don't count the l2 regulazation(weight decay), but tf counts

8. all affine are set True to match the params

9. add some function to get the default arch(the architecture searched reported in paper) and test the model
